### PR TITLE
Tree drawer improve

### DIFF
--- a/DataStructures/Common/Helpers.cs
+++ b/DataStructures/Common/Helpers.cs
@@ -49,11 +49,7 @@ namespace DataStructures.Common
             //add a space to the left if the string is an odd number
             int padRight = charactersToPad / 2;
 
-            StringBuilder resultBuilder = new StringBuilder(newWidth);
-            for (int i = 0; i < padLeft; i++) resultBuilder.Insert(i, fillerCharacter);
-            for (int i = 0; i < length; i++) resultBuilder.Insert(i + padLeft, text[i]);
-            for (int i = newWidth - padRight; i < newWidth; i++) resultBuilder.Insert(i, fillerCharacter);
-            return resultBuilder.ToString();
+            return new String(fillerCharacter, padLeft) + text + new String(fillerCharacter, padRight);
         }
 
         /// <summary>

--- a/DataStructures/Trees/TreeDrawer.cs
+++ b/DataStructures/Trees/TreeDrawer.cs
@@ -30,11 +30,11 @@ namespace DataStructures.Trees
         /// <summary>
         /// /// Recusively draws the tree starting from node.
         /// To construct a full tree representation concatenate the returned list of strings by '\n'.
-        /// 
+        ///
         /// Example:
         /// int position, width;
         /// var fullTree = String.Join("\n", _recursivelyDrawTree(this.Root, out position, out width));
-        /// 
+        ///
         /// Algorithm developed by MIT OCW.
         /// http://ocw.mit.edu/courses/electrical-engineering-and-computer-science/6-006-introduction-to-algorithms-fall-2011/readings/binary-search-trees/bstsize_r.py
         /// </summary>
@@ -43,43 +43,35 @@ namespace DataStructures.Trees
         /// <param name="widthOutput"></param>
         /// <returns>List of tree levels as strings.</returns>
         private static List<string> _recursivelyDrawTree<T>
-            (BSTNode<T> node, out int positionOutput, out int widthOutput) 
+            (BSTNode<T> node, out int positionOutput, out int widthOutput)
             where T : IComparable<T>
         {
             widthOutput = 0;
             positionOutput = 0;
-            List<string> listOfLines = new List<string>();
 
             if (node == null)
             {
-                return listOfLines;
+                return new List<string>();
             }
 
             //
             // Variables
-            string nodeLabel;
-
-            List<string> leftLines, rightLines;
-            leftLines = rightLines = new List<string>();
-
-            int leftPosition = 0, rightPosition = 0;
-            int leftWidth = 0, rightWidth = 0;
-            int middle, position_out, width_out;
+            int leftPosition, rightPosition, leftWidth, rightWidth;
 
             //
             // Start drawing
-            nodeLabel = Convert.ToString(node.Value);
+            var nodeLabel = Convert.ToString(node.Value);
 
             // Visit the left child
-            leftLines = _recursivelyDrawTree(node.LeftChild, out leftPosition, out leftWidth);
+            List<string> leftLines = _recursivelyDrawTree(node.LeftChild, out leftPosition, out leftWidth);
 
             // Visit the right child
-            rightLines = _recursivelyDrawTree(node.RightChild, out rightPosition, out rightWidth);
+            List<string> rightLines = _recursivelyDrawTree(node.RightChild, out rightPosition, out rightWidth);
 
             // Calculate pads
-            middle = Math.Max(Math.Max(2, nodeLabel.Length), (rightPosition + leftWidth - leftPosition + 1));
-            position_out = leftPosition + middle;
-            width_out = leftPosition + middle + rightWidth - rightPosition;
+            int middle = Math.Max(Math.Max(2, nodeLabel.Length), (rightPosition + leftWidth - leftPosition + 1));
+            int position_out = leftPosition + middle / 2;
+            int width_out = leftPosition + middle + rightWidth - rightPosition;
 
             while (leftLines.Count < rightLines.Count)
                 leftLines.Add(new String(' ', leftWidth));
@@ -105,23 +97,22 @@ namespace DataStructures.Trees
 
             //
             // Construct the list of lines.
-            listOfLines = new List<string>()
+            string leftBranch = node.HasLeftChild ? "/" : " ";
+            string rightBranch = node.HasRightChild ? "\\" : " ";
+
+            List<string> listOfLines = new List<string>()
             {
                 // 0
                 (new String(' ', leftPosition )) + nodeLabel + (new String(' ', (rightWidth - rightPosition))),
 
                 // 1
-                (new String(' ', leftPosition)) + "/" + (new String(' ', (middle - 2))) + "\\" + (new String(' ', (rightWidth - rightPosition))) 
+                (new String(' ', leftPosition)) + leftBranch + (new String(' ', (middle - 2))) + rightBranch + (new String(' ', (rightWidth - rightPosition)))
             };
 
             //
             // Add the right lines and left lines to the final list of lines.
-            listOfLines =
-                listOfLines.Concat(
-                    leftLines.Zip(
-                        rightLines, (left_line, right_line) =>
-                            left_line + (new String(' ', (width_out - leftWidth - rightWidth))) + right_line)
-                ).ToList();
+            listOfLines.AddRange(leftLines.Zip(rightLines, (leftLine, rightLine) =>
+                            leftLine + (new String(' ', (width_out - leftWidth - rightWidth))) + rightLine));
 
             //
             // Return
@@ -210,7 +201,7 @@ namespace DataStructures.Trees
                     (new String(' ', leftPosition )) + nodeLabel + (new String(' ', (rightWidth - rightPosition))),
 
                     // 1
-                    (new String(' ', leftPosition)) + "/" + (new String(' ', (middle - padValue))) + "\\" + (new String(' ', (rightWidth - rightPosition))) 
+                    (new String(' ', leftPosition)) + "/" + (new String(' ', (middle - padValue))) + "\\" + (new String(' ', (rightWidth - rightPosition)))
                 };
 
             //

--- a/MainProgram/DataStructuresTests/AVLTreeTest.cs
+++ b/MainProgram/DataStructuresTests/AVLTreeTest.cs
@@ -22,8 +22,8 @@ namespace C_Sharp_Algorithms.DataStructuresTests
              **     4                   5
              **      \                 / \
              **       5       ===>    4   7
-             **        \ 
-             **         7 
+             **        \
+             **         7
              **
              ***************************************
              */
@@ -65,7 +65,7 @@ namespace C_Sharp_Algorithms.DataStructuresTests
             // DOUBLE *right* rotation for node 5.
             //
             // The double rotation is achieved by:
-            // 1> Simple *left* rotation for node 2, and then 
+            // 1> Simple *left* rotation for node 2, and then
             // 2> Simple *right* rotation for node 5
             //
             /*************************************
@@ -92,7 +92,7 @@ namespace C_Sharp_Algorithms.DataStructuresTests
             // DOUBLE *right* rotation for node 5.
             //
             // The double rotation is achieved by:
-            // 1> Simple *right* rotation for node 7, and then 
+            // 1> Simple *right* rotation for node 7, and then
             // 2> Simple *left* rotation for node 5
             //
             /**************************************************************************
@@ -119,7 +119,7 @@ namespace C_Sharp_Algorithms.DataStructuresTests
             //
             /**************************************************************************
              ** UNBALANCED     ===>    TRANSITION (1st R)    ===>    BALANCED (2nd Rt)
-             **       null                                              .6.. 
+             **       null                                              .6..
              **      /   \                                             /    \
              **     2     6    ===>                      ===>         2      7
              **    / \   / \                                         / \    /
@@ -132,7 +132,7 @@ namespace C_Sharp_Algorithms.DataStructuresTests
             // ASSERT CASE 5
             AssertCase_5(avlTree);
 
-            
+
             //
             // CLEAR THE TREE AND START OVER
             // Compare two binary trees with each other (height-wise) using bulk-inserts
@@ -152,31 +152,26 @@ namespace C_Sharp_Algorithms.DataStructuresTests
 
             //
             // Draw the tree to the console.
-            Console.WriteLine(String.Format("************\r\n** BST TREE:\r\n************\r\n"));
+            Console.WriteLine("************\r\n** BST TREE:\r\n************\r\n");
             Console.WriteLine(bsTree.DrawTree());
 
             Console.WriteLine("\r\n\r\n");
 
-            Console.WriteLine(String.Format("************\r\n** AVL TREE:\r\n************\r\n"));
+            Console.WriteLine("************\r\n** AVL TREE:\r\n************\r\n");
             Console.WriteLine(avlTree.DrawTree());
 
             //
             // OUTPUT OF AVL TREE DRAWER
-            /*****
-             ** ************
-             ** ** AVL TREE:
-             ** ************
-             **                    ....15...
-             **                   /         \
-             **             ...9..      ..20.
-             **            /      \    /     \
-             **       ..5.      11   16    28
-             **      /    \    /  \ / \   /  \
-             **    1     7   9   12  19 25  30
-             **    /\   / \ / \ / \  /\ /\ / \
-             **  -1   7   8  10  13         39
-             **  /\   /\ /\  /\  /\         /\
-             *  
+            /**
+             **          .....15....
+             **         /           \
+             **      ...9...        .20
+             **     /       \      /   \
+             **    .5       11    16    28
+             **   /  \     /  \    \   / \
+             **  1    7   9   12   19 25 30
+             **  /   / \   \   \          \
+             ** -1  7   8  10  13         39
              */
 
 
@@ -184,24 +179,21 @@ namespace C_Sharp_Algorithms.DataStructuresTests
             avlTree.Clear();
             avlTree.Insert(treeDataList);
 
-            Console.WriteLine(String.Format("************\r\n** AVL TREE:\r\n************\r\n"));
+            Console.WriteLine("************\r\n** AVL TREE:\r\n************\r\n");
             Console.WriteLine(avlTree.DrawTree());
 
             //
             // OUTPUT OF AVL TREE DRAWER
-            /*****
-             ** 
-             **           .......9......
-             **          /              \
-             **       .5       ....12...
-             **      /  \     /         \
-             **    1   7    11      .25.
-             **    /\ / \   /\     /    \
-             **  -1     8  10    15    30
-             **  /\    /\  /\    /\   / \
-             **                 13   28 39
-             **                 /\   /\ /\
-             **
+            /**
+             **     ....9...
+             **    /        \
+             **    5       .12.
+             **   / \     /    \
+             **  1   7   11    25
+             **  /   \   /    /  \
+             ** -1    8 10   15   30
+             **              /   / \
+             **             13  28 39
              */
 
             Console.ReadLine();


### PR DESCRIPTION
I found that the result of TreeDrawer do not match with the implement of python version.(You can checkout the difference between these in AVLTreeTest.cs)

After reading the code from [bstsize_r.py](http://ocw.mit.edu/courses/electrical-engineering-and-computer-science/6-006-introduction-to-algorithms-fall-2011/readings/binary-search-trees/bstsize_r.py), I found out that the `int position_out = leftPosition + middle / 2;` in your code missed an `/2`;

Meanwhile, I remove the branch(`@"/\"`) display while a node without child nodes for a better result.
