### PR TITLE
Fix bug for the remove method of BinarySearchTree

### DIFF
--- a/DataStructures/Trees/AugmentedBinarySearchTree.cs
+++ b/DataStructures/Trees/AugmentedBinarySearchTree.cs
@@ -146,7 +146,7 @@ namespace DataStructures.Trees
 
             if (node.ChildrenCount == 2) // if both children are present
             {
-                var successor = node.RightChild;
+                var successor = _findNextLarger(node);
                 node.Value = successor.Value;
                 return (true && _remove(successor));
             }

--- a/DataStructures/Trees/BinarySearchTree.cs
+++ b/DataStructures/Trees/BinarySearchTree.cs
@@ -77,6 +77,10 @@ namespace DataStructures.Trees
                 else
                     node.Parent.RightChild = newNode;
             }
+            else
+            {
+                Root = newNode;
+            }
 
             if (newNode != null)
                 newNode.Parent = node.Parent;
@@ -96,7 +100,7 @@ namespace DataStructures.Trees
 
             if (node.ChildrenCount == 2) // if both children are present
             {
-                var successor = node.RightChild;
+                var successor = _findNextLarger(node);
                 node.Value = successor.Value;
                 return (true && _remove(successor));
             }


### PR DESCRIPTION
Fix two bugs for the remove method:

Bug 1: When the node to be removed has two children ,  should remove the successor (nextLarger) node, not the right child.   
For example, given a tree (A),  if we remove node 2, the tree should looks like (B), but now it actually  looks like (C).  
<pre>
         (A)                   (B)                    (C)
          8                     8                      8
         / \                   / \                    / \ 
        2   9                 3   9                  5   9        
       / \                   / \                    / \
      1   5                 1   5                  1   6
         / \                     \                    /   
        3   6                     6                  3      
</pre>
Bug 2:  If we remove the root of the tree, should assign the new child node to the root.
For exmaple, given a tree (A),  if we remove node 6, it should looks like (B), but now it looks like (C).
<pre>
      (A)                   (B)                (C)
Root ->  6             Root -> 8         Root -> 6
          \                   / \
           8                 7   9                8
          / \                                    / \
         7   9                                  7   9
</pre>