### PR TITLE
Added .idea/ to .gitignore for JetBrains Rider IDE

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -189,3 +189,4 @@ GeneratedArtifacts/
 _Pvt_Extensions/
 ModelManifest.xml
 .vs/
+.idea/


### PR DESCRIPTION
".idea/" is the working directory for the JetBrains Rider IDE, similar to the ".vs" directory of visual studio.