### PR TITLE
Fixed warnings generated on build.

### DIFF
--- a/DataStructures/Dictionaries/CuckooHashTable.cs
+++ b/DataStructures/Dictionaries/CuckooHashTable.cs
@@ -22,13 +22,11 @@ namespace DataStructures.Dictionaries
         /// <summary>
         /// THE CUCKOO HASH TABLE ENTERY
         /// </summary>
-        private class CHashEntry<TKey, TValue> where TKey : IComparable<TKey>
+        private class CHashEntry
         {
-            public TKey Key { get; set; }
+            public TKey Key { get; }
             public TValue Value { get; set; }
             public bool IsActive { get; set; }
-
-            public CHashEntry() : this(default(TKey), default(TValue), false) { }
 
             public CHashEntry(TKey key, TValue value, bool isActive)
             {
@@ -53,7 +51,7 @@ namespace DataStructures.Dictionaries
 
         private int _size { get; set; }
         private int _numberOfRehashes { get; set; }
-        private CHashEntry<TKey, TValue>[] _collection { get; set; }
+        private CHashEntry[] _collection { get; set; }
         private UniversalHashingFamily _universalHashingFamily { get; set; }
         private EqualityComparer<TKey> _equalityComparer = EqualityComparer<TKey>.Default;
 
@@ -70,7 +68,7 @@ namespace DataStructures.Dictionaries
             _size = 0;
             _numberOfRehashes = 0;
             _randomizer = new Random();
-            _collection = new CHashEntry<TKey, TValue>[DEFAULT_CAPACITY];
+            _collection = new CHashEntry[DEFAULT_CAPACITY];
             _universalHashingFamily = new UniversalHashingFamily(NUMBER_OF_HASH_FUNCTIONS);
         }
 
@@ -121,7 +119,7 @@ namespace DataStructures.Dictionaries
 
             try
             {
-                this._collection = new CHashEntry<TKey, TValue>[newCapacity];
+                this._collection = new CHashEntry[newCapacity];
 
                 // Reset size
                 _size = 0;
@@ -192,7 +190,7 @@ namespace DataStructures.Dictionaries
         private void _insertHelper(TKey key, TValue value)
         {
             int COUNT_LIMIT = 100;
-            var newEntry = new CHashEntry<TKey, TValue>(key, value, isActive: true);
+            var newEntry = new CHashEntry(key, value, isActive: true);
 
             while (true)
             {
@@ -283,7 +281,7 @@ namespace DataStructures.Dictionaries
             }
             set
             {
-                if (ContainsKey(key) == true)
+                if (ContainsKey(key))
                     Update(key, value);
 
                 throw new KeyNotFoundException();
@@ -356,7 +354,7 @@ namespace DataStructures.Dictionaries
             Parallel.ForEach(_collection,
                 (item) =>
                 {
-                    if (item != null && item.IsActive == true)
+                    if (item != null && item.IsActive)
                     {
                         item.IsActive = false;
                     }

--- a/DataStructures/Dictionaries/OpenAddressingHashTable.cs
+++ b/DataStructures/Dictionaries/OpenAddressingHashTable.cs
@@ -15,9 +15,7 @@ namespace DataStructures.Dictionaries
         /// <summary>
         /// Open Addressing Entry
         /// </summary>
-        /// <typeparam name="TKey"></typeparam>
-        /// <typeparam name="TValue"></typeparam>
-        private class OAHashEntry<TKey, TValue> where TKey : IComparable<TKey>
+        private class OAHashEntry
         {
             public TKey key { get; set; }
             public TValue value { get; set; }
@@ -33,7 +31,7 @@ namespace DataStructures.Dictionaries
         private int _size { get; set; }
         private double _loadFactor { get; set; }
         private int _inTable { get; set; }
-        private OAHashEntry<TKey, TValue>[] _table { get; set; }
+        private OAHashEntry[] _table { get; set; }
         private List<TKey> _keys { get; set; }
         private List<TValue> _values { get; set; }
 
@@ -46,7 +44,7 @@ namespace DataStructures.Dictionaries
             _size = size;
             _loadFactor = 0.40;
             _inTable = 0;
-            _table = new OAHashEntry<TKey, TValue>[_size];
+            _table = new OAHashEntry[_size];
             _keys = new List<TKey>();
             _values = new List<TValue>();
 
@@ -54,7 +52,7 @@ namespace DataStructures.Dictionaries
             for (int i = 0; i < _table.Length; i++)
             {
                 //initialize each slot
-                _table[i] = new OAHashEntry<TKey, TValue>(default(TKey), default(TValue), false);
+                _table[i] = new OAHashEntry(default(TKey), default(TValue), false);
             }
         }
 
@@ -62,15 +60,15 @@ namespace DataStructures.Dictionaries
         private void _expand()
         {
             //will hold contents of _table to copy over
-            OAHashEntry<TKey, TValue>[] temp = new OAHashEntry<TKey, TValue>[_size];
+            var temp = new OAHashEntry[_size];
             temp = _table;
             //double the size and rehash
             _size *= 2;
-            OAHashEntry<TKey, TValue>[] exp = new OAHashEntry<TKey, TValue>[_size];
+            var exp = new OAHashEntry[_size];
             for (int i = 0; i < exp.Length; i++)
             {
                 //initialize each slot
-                exp[i] = new OAHashEntry<TKey, TValue>(default(TKey), default(TValue), false);
+                exp[i] = new OAHashEntry(default(TKey), default(TValue), false);
             }
 
             _inTable = 0;
@@ -88,14 +86,14 @@ namespace DataStructures.Dictionaries
         private void _rehash()
         {
             //will hold contents of _table to copy over
-            OAHashEntry<TKey, TValue>[] temp = new OAHashEntry<TKey, TValue>[_size];
+            var temp = new OAHashEntry[_size];
             temp = _table;
 
-            OAHashEntry<TKey, TValue>[] rehash = new OAHashEntry<TKey, TValue>[_size];
+            var rehash = new OAHashEntry[_size];
             for (int i = 0; i < rehash.Length; i++)
             {
                 //initialize each slot
-                rehash[i] = new OAHashEntry<TKey, TValue>(default(TKey), default(TValue), false);
+                rehash[i] = new OAHashEntry(default(TKey), default(TValue), false);
             }
 
             _inTable = 0;
@@ -183,7 +181,7 @@ namespace DataStructures.Dictionaries
 
                 if (_table[index].occupied == false)
                 {
-                    var newEntry = new OAHashEntry<TKey, TValue>(key, value, true);
+                    var newEntry = new OAHashEntry(key, value, true);
                     _keys.Add(key);
                     _values.Add(value);
 
@@ -217,7 +215,7 @@ namespace DataStructures.Dictionaries
         public TValue this[TKey key]
         {
             get{
-                int index = search(key);
+                int index = Search(key);
 
                 if (index != -1)
                 {
@@ -228,10 +226,10 @@ namespace DataStructures.Dictionaries
             }
             set {
 
-                if (ContainsKey(key) == true)
+                if (ContainsKey(key))
                 {
 
-                    int index = search(key);
+                    int index = Search(key);
 
                     _table[index].value = value;
 
@@ -250,7 +248,7 @@ namespace DataStructures.Dictionaries
             if (ContainsKey(key))
             {
                 //find position and reset values
-                int index = search(key);
+                int index = Search(key);
                 _keys.Clear();
                 _values.Clear();
 
@@ -294,7 +292,7 @@ namespace DataStructures.Dictionaries
         //Tries to get the value of key which might not be in the dictionary.
         public bool TryGetValue(TKey key, out TValue value)
         {
-            int index = search(key);
+            int index = Search(key);
 
             if (index != -1)
             {
@@ -309,7 +307,7 @@ namespace DataStructures.Dictionaries
         }
 
         //finds the key and returns index in the table
-        public int search(TKey key)
+        public int Search(TKey key)
         {
             int i = 0;
 
@@ -331,7 +329,7 @@ namespace DataStructures.Dictionaries
         //returns true if the key is in the table
         public bool ContainsKey(TKey key)
         {
-            if (search(key) != -1)
+            if (Search(key) != -1)
             {
                 return true;
             }

--- a/DataStructures/Dictionaries/OpenScatterHashTable.cs
+++ b/DataStructures/Dictionaries/OpenScatterHashTable.cs
@@ -13,7 +13,7 @@ namespace DataStructures.Dictionaries
         /// <summary>
         /// Hash Table Cell.
         /// </summary>
-        private class HashTableEntry<TKey, TValue> where TKey : IComparable<TKey>
+        private class HashTableEntry
         {
             public TKey Key { get; set; }
             public TValue Value { get; set; }
@@ -34,18 +34,15 @@ namespace DataStructures.Dictionaries
             public bool IsDeleted { get { return this.Status == EntryStatus.Deleted; } }
         }
 
-
-
         /// <summary>
         /// INSTANCE VARIABLES
         /// </summary>
-        private int _size;
-        private decimal _loadFactor;
-        private HashTableEntry<TKey, TValue>[] _hashTableStore;
+        private int _size = 0;
+        private HashTableEntry[] _hashTableStore;
 
         // Initialization-related
         private const int _defaultCapacity = 7;
-        private static readonly HashTableEntry<TKey, TValue>[] _emptyArray = new HashTableEntry<TKey, TValue>[_defaultCapacity];
+        private static readonly HashTableEntry[] _emptyArray = new HashTableEntry[_defaultCapacity];
 
         // Helper collections.
         private List<TKey> _keysCollection { get; set; }
@@ -120,7 +117,7 @@ namespace DataStructures.Dictionaries
                 int newCapacity = (_hashTableStore.Length == 0 ? _defaultCapacity : _getContractPrime(_hashTableStore.Length));
 
                 // Try to expand the size
-                HashTableEntry<TKey, TValue>[] newKeysMap = new HashTableEntry<TKey, TValue>[newCapacity];
+                var newKeysMap = new HashTableEntry[newCapacity];
 
                 if (_size > 0)
                 {
@@ -144,21 +141,14 @@ namespace DataStructures.Dictionaries
                     newCapacity = MAX_PRIME_ARRAY_LENGTH;
 
                 // Try to expand the size
-                try
-                {
-                    HashTableEntry<TKey, TValue>[] newKeysMap = new HashTableEntry<TKey, TValue>[newCapacity];
+                var newKeysMap = new HashTableEntry[newCapacity];
 
-                    if (_size > 0)
-                    {
-                        // REHASH
-                    }
-
-                    _hashTableStore = newKeysMap;
-                }
-                catch (OutOfMemoryException)
+                if (_size > 0)
                 {
-                    throw;
+                    // REHASH
                 }
+
+                _hashTableStore = newKeysMap;
             }
         }
 

--- a/DataStructures/Graphs/DirectedWeightedDenseGraph.cs
+++ b/DataStructures/Graphs/DirectedWeightedDenseGraph.cs
@@ -80,7 +80,7 @@ namespace DataStructures.Graphs
         /// <summary>
         /// An enumerable collection of all weighted directed edges in graph.
         /// </summary>
-        public virtual IEnumerable<WeightedEdge<T>> Edges
+        public new virtual IEnumerable<WeightedEdge<T>> Edges
         {
             get
             {
@@ -93,7 +93,7 @@ namespace DataStructures.Graphs
         /// <summary>
         /// Get all incoming unweighted edges to a vertex.
         /// </summary>
-        public virtual IEnumerable<WeightedEdge<T>> IncomingEdges(T vertex)
+        public new virtual IEnumerable<WeightedEdge<T>> IncomingEdges(T vertex)
         {
             if (!HasVertex(vertex))
                 throw new KeyNotFoundException("Vertex doesn't belong to graph.");
@@ -116,7 +116,7 @@ namespace DataStructures.Graphs
         /// <summary>
         /// Get all outgoing unweighted edges from a vertex.
         /// </summary>
-        public virtual IEnumerable<WeightedEdge<T>> OutgoingEdges(T vertex)
+        public new virtual IEnumerable<WeightedEdge<T>> OutgoingEdges(T vertex)
         {
             if (!HasVertex(vertex))
                 throw new KeyNotFoundException("Vertex doesn't belong to graph.");

--- a/DataStructures/Graphs/UndirectedWeightedDenseGraph.cs
+++ b/DataStructures/Graphs/UndirectedWeightedDenseGraph.cs
@@ -78,7 +78,7 @@ namespace DataStructures.Graphs
         /// <summary>
         /// An enumerable collection of edges.
         /// </summary>
-        public virtual IEnumerable<WeightedEdge<T>> Edges
+        public new virtual IEnumerable<WeightedEdge<T>> Edges
         {
             get
             {
@@ -115,7 +115,7 @@ namespace DataStructures.Graphs
         /// <summary>
         /// Get all incoming edges to a vertex
         /// </summary>
-        public virtual IEnumerable<WeightedEdge<T>> IncomingEdges(T vertex)
+        public new virtual IEnumerable<WeightedEdge<T>> IncomingEdges(T vertex)
         {
             if (!HasVertex(vertex))
                 throw new KeyNotFoundException("Vertex doesn't belong to graph.");
@@ -138,7 +138,7 @@ namespace DataStructures.Graphs
         /// <summary>
         /// Get all outgoing weighted edges from vertex
         /// </summary>
-        public virtual IEnumerable<WeightedEdge<T>> OutgoingEdges(T vertex)
+        public new virtual IEnumerable<WeightedEdge<T>> OutgoingEdges(T vertex)
         {
             if (!HasVertex(vertex))
                 throw new KeyNotFoundException("Vertex doesn't belong to graph.");
@@ -149,11 +149,11 @@ namespace DataStructures.Graphs
             {
                 if (_vertices[adjacent] != null && _doesEdgeExist(source, adjacent))
                 {
-                    yield return (new WeightedEdge<T>(
+                    yield return new WeightedEdge<T>(
                         vertex,                             // from
                         (T)_vertices[adjacent],             // to
                         _getEdgeWeight(source, adjacent)    // weight
-                    ));
+                    );
                 }
             }//end-for
         }

--- a/DataStructures/Heaps/BinomialMinHeap.cs
+++ b/DataStructures/Heaps/BinomialMinHeap.cs
@@ -14,17 +14,17 @@ namespace DataStructures.Heaps
         /// <summary>
         /// The Heap Node class.
         /// </summary>
-        private class BinomialNode<T> where T : IComparable<T>
+        private class BinomialNode
         {
             public T Value { get; set; }
-            public BinomialNode<T> Parent { get; set; }
-            public BinomialNode<T> Sibling { get; set; }    // Right-Sibling
-            public BinomialNode<T> Child { get; set; }      // Left-Child
+            public BinomialNode Parent { get; set; }
+            public BinomialNode Sibling { get; set; }    // Right-Sibling
+            public BinomialNode Child { get; set; }      // Left-Child
 
             // Constructors
             public BinomialNode() : this(default(T), null, null, null) { }
             public BinomialNode(T value) : this(value, null, null, null) { }
-            public BinomialNode(T value, BinomialNode<T> parent, BinomialNode<T> sibling, BinomialNode<T> child)
+            public BinomialNode(T value, BinomialNode parent, BinomialNode sibling, BinomialNode child)
             {
                 Value = value;
                 Parent = parent;
@@ -50,7 +50,7 @@ namespace DataStructures.Heaps
         /// </summary>
         private int _size { get; set; }
         private const int _defaultCapacity = 8;
-        private ArrayList<BinomialNode<T>> _forest { get; set; }
+        private ArrayList<BinomialNode> _forest { get; set; }
 
 
         /// <summary>
@@ -70,7 +70,7 @@ namespace DataStructures.Heaps
             capacity = (capacity < _defaultCapacity ? _defaultCapacity : capacity);
 
             _size = 0;
-            _forest = new ArrayList<BinomialNode<T>>(capacity);
+            _forest = new ArrayList<BinomialNode>(capacity);
         }
 
 
@@ -85,7 +85,7 @@ namespace DataStructures.Heaps
         {
             // Get the deletedTree
             // The min-root lies at _forest[minIndex]
-            BinomialNode<T> deletedTreeRoot = _forest[minIndex].Child;
+            var deletedTreeRoot = _forest[minIndex].Child;
 
             // Exit if there was no children under old-min-root
             if (deletedTreeRoot == null)
@@ -135,7 +135,7 @@ namespace DataStructures.Heaps
         /// <summary>
         /// Combines two trees and returns the new tree root node.
         /// </summary>
-        private BinomialNode<T> _combineTrees(BinomialNode<T> firstTreeRoot, BinomialNode<T> secondTreeRoot)
+        private BinomialNode _combineTrees(BinomialNode firstTreeRoot, BinomialNode secondTreeRoot)
         {
             if (firstTreeRoot == null || secondTreeRoot == null)
                 throw new ArgumentNullException("Either one of the nodes or both are null.");
@@ -153,12 +153,12 @@ namespace DataStructures.Heaps
         /// <summary>
         /// Clones a tree, given it's root node.
         /// </summary>
-        private BinomialNode<T> _cloneTree(BinomialNode<T> treeRoot)
+        private BinomialNode _cloneTree(BinomialNode treeRoot)
         {
             if (treeRoot == null)
                 return null;
             else
-                return new BinomialNode<T>() { Value = treeRoot.Value, Child = _cloneTree(treeRoot.Child), Sibling = _cloneTree(treeRoot.Sibling) };
+                return new BinomialNode() { Value = treeRoot.Value, Child = _cloneTree(treeRoot.Child), Sibling = _cloneTree(treeRoot.Sibling) };
         }
 
 
@@ -194,7 +194,7 @@ namespace DataStructures.Heaps
             if (newCollection.Count > ArrayList<T>.MAXIMUM_ARRAY_LENGTH_x64)
                 throw new OverflowException();
 
-            _forest = new ArrayList<BinomialNode<T>>(newCollection.Count + 1);
+            _forest = new ArrayList<BinomialNode>(newCollection.Count + 1);
 
             for (int i = 0; i < newCollection.Count; ++i)
                 this.Add(newCollection[i]);
@@ -206,7 +206,7 @@ namespace DataStructures.Heaps
         public void Add(T heapKey)
         {
             var tempHeap = new BinomialMinHeap<T>();
-            tempHeap._forest.Add(new BinomialNode<T>(heapKey));
+            tempHeap._forest.Add(new BinomialNode(heapKey));
             tempHeap._size = 1;
 
             // Merge this with tempHeap
@@ -272,7 +272,7 @@ namespace DataStructures.Heaps
             if (otherHeap == null || otherHeap.IsEmpty)
                 return;
 
-            BinomialNode<T> carryNode = null;
+            BinomialNode carryNode = null;
             _size = _size + otherHeap._size;
 
             // One capacity-change step
@@ -284,8 +284,8 @@ namespace DataStructures.Heaps
 
             for (int i = 0, j = 1; j <= _size; i++, j *= 2)
             {
-                BinomialNode<T> treeRoot1 = (_forest.IsEmpty == true ? null : _forest[i]);
-                BinomialNode<T> treeRoot2 = (i < otherHeap._forest.Count ? otherHeap._forest[i] : null);
+                var treeRoot1 = _forest.IsEmpty ? null : _forest[i];
+                var treeRoot2 = i < otherHeap._forest.Count ? otherHeap._forest[i] : null;
 
                 int whichCase = (treeRoot1 == null ? 0 : 1);
                 whichCase += (treeRoot2 == null ? 0 : 2);


### PR DESCRIPTION
This fixes all of the warnings generated when running the build.

The template parameters are inherited from the embedding class, making their definition redundant (on top of re-using the same name, as the warning described).

The "new" on several functions is because the return type is different. I suspect that they actually behave identically, and the only difference *is* the return type, but I wanted to focus this PR on simply fixing warnings first, and I'll revisit the Edges later.