### PR TITLE
Add customized edge weight support for graphs.

### DIFF
--- a/DataStructures/Graphs/CliqueGraph.cs
+++ b/DataStructures/Graphs/CliqueGraph.cs
@@ -255,7 +255,7 @@ namespace DataStructures.Graphs
         /// <summary>
         /// An enumerable collection of all graph edges.
         /// </summary>
-        public IEnumerable<IEdge<T>> Edges
+        public IEnumerable<IEdge<T, Int64>> Edges
         {
             get
             {
@@ -273,7 +273,7 @@ namespace DataStructures.Graphs
         /// <summary>
         /// Get all incoming edges to vertex.
         /// </summary>
-        public IEnumerable<IEdge<T>> IncomingEdges(T vertex)
+        public IEnumerable<IEdge<T, Int64>> IncomingEdges(T vertex)
         {
             List<UnweightedEdge<T>> incomingEdges = new List<UnweightedEdge<T>>();
 
@@ -296,7 +296,7 @@ namespace DataStructures.Graphs
         /// <summary>
         /// Get all outgoing edges from a vertex.
         /// </summary>
-        public IEnumerable<IEdge<T>> OutgoingEdges(T vertex)
+        public IEnumerable<IEdge<T, Int64>> OutgoingEdges(T vertex)
         {
             List<UnweightedEdge<T>> outgoingEdges = new List<UnweightedEdge<T>>();
 
@@ -394,7 +394,7 @@ namespace DataStructures.Graphs
         /// Adds a list of vertices to the graph.
         /// </summary>
         /// <param name="collection">Collection.</param>
-        void IGraph<T>.AddVertices(IList<T> collection)
+        void IGraph<T, Int64>.AddVertices(IList<T> collection)
         {
             AddVertices(collection);
         }
@@ -598,7 +598,7 @@ namespace DataStructures.Graphs
         /// Returns the list of Vertices.
         /// </summary>
         /// <value>The vertices.</value>
-        IEnumerable<T> IGraph<T>.Vertices
+        IEnumerable<T> IGraph<T, Int64>.Vertices
         {
             get
             {

--- a/DataStructures/Graphs/DirectedDenseGraph.cs
+++ b/DataStructures/Graphs/DirectedDenseGraph.cs
@@ -102,17 +102,17 @@ namespace DataStructures.Graphs
         }
 
 
-        IEnumerable<IEdge<T>> IGraph<T>.Edges
+        IEnumerable<IEdge<T, Int64>> IGraph<T, Int64>.Edges
         {
             get { return this.Edges; }
         }
 
-        IEnumerable<IEdge<T>> IGraph<T>.IncomingEdges(T vertex)
+        IEnumerable<IEdge<T, Int64>> IGraph<T, Int64>.IncomingEdges(T vertex)
         {
             return this.IncomingEdges(vertex);
         }
 
-        IEnumerable<IEdge<T>> IGraph<T>.OutgoingEdges(T vertex)
+        IEnumerable<IEdge<T, Int64>> IGraph<T, Int64>.OutgoingEdges(T vertex)
         {
             return this.OutgoingEdges(vertex);
         }

--- a/DataStructures/Graphs/DirectedSparseGraph.cs
+++ b/DataStructures/Graphs/DirectedSparseGraph.cs
@@ -92,17 +92,17 @@ namespace DataStructures.Graphs
         }
 
 
-        IEnumerable<IEdge<T>> IGraph<T>.Edges
+        IEnumerable<IEdge<T, Int64>> IGraph<T, Int64>.Edges
         {
             get { return this.Edges; }
         }
 
-        IEnumerable<IEdge<T>> IGraph<T>.IncomingEdges(T vertex)
+        IEnumerable<IEdge<T, Int64>> IGraph<T, Int64>.IncomingEdges(T vertex)
         {
             return this.IncomingEdges(vertex);
         }
 
-        IEnumerable<IEdge<T>> IGraph<T>.OutgoingEdges(T vertex)
+        IEnumerable<IEdge<T, Int64>> IGraph<T, Int64>.OutgoingEdges(T vertex)
         {
             return this.OutgoingEdges(vertex);
         }

--- a/DataStructures/Graphs/DirectedWeightedDenseGraph.cs
+++ b/DataStructures/Graphs/DirectedWeightedDenseGraph.cs
@@ -23,18 +23,18 @@ namespace DataStructures.Graphs
     /// <summary>
     /// This class represents the graph as an adjacency-matrix (two dimensional integer array).
     /// </summary>
-    public class DirectedWeightedDenseGraph<T> : DirectedDenseGraph<T>, IWeightedGraph<T> where T : IComparable<T>
+    public class DirectedWeightedDenseGraph<T, W> : DirectedDenseGraph<T>, IWeightedGraph<T, W> where T : IComparable<T> where W : IComparable<W>
     {
         /// <summary>
         /// INSTANCE VARIABLES
         /// </summary>
-        private const long EMPTY_EDGE_SLOT = 0;
+        private static readonly W EMPTY_EDGE_SLOT = default(W);
         private const object EMPTY_VERTEX_SLOT = (object)null;
 
         // Store edges and their weights as integers.
         // Any edge with a value of zero means it doesn't exist. Otherwise, it exist with a specific weight value.
         // Default value for positive edges is 1.
-        protected new long[,] _adjacencyMatrix { get; set; }
+        protected new W[,] _adjacencyMatrix { get; set; }
 
 
         /// <summary>
@@ -47,7 +47,7 @@ namespace DataStructures.Graphs
             _verticesCapacity = (int)capacity;
 
             _vertices = new ArrayList<object>(_verticesCapacity);
-            _adjacencyMatrix = new long[_verticesCapacity, _verticesCapacity];
+            _adjacencyMatrix = new W[_verticesCapacity, _verticesCapacity];
             _adjacencyMatrix.Populate(rows: _verticesCapacity, columns: _verticesCapacity, defaultValue: EMPTY_EDGE_SLOT);
         }
 
@@ -57,13 +57,13 @@ namespace DataStructures.Graphs
         /// </summary>
         protected override bool _doesEdgeExist(int source, int destination)
         {
-            return (_adjacencyMatrix[source, destination] != EMPTY_EDGE_SLOT);
+            return (EMPTY_EDGE_SLOT.Equals(_adjacencyMatrix[source, destination]));
         }
 
         /// <summary>
         /// Helper function. Gets the weight of a directed edge.
         /// </summary>
-        private long _getEdgeWeight(int source, int destination)
+        private W _getEdgeWeight(int source, int destination)
         {
             return _adjacencyMatrix[source, destination];
         }
@@ -80,7 +80,7 @@ namespace DataStructures.Graphs
         /// <summary>
         /// An enumerable collection of all weighted directed edges in graph.
         /// </summary>
-        public virtual IEnumerable<WeightedEdge<T>> Edges
+        public new virtual IEnumerable<WeightedEdge<T, W>> Edges
         {
             get
             {
@@ -93,7 +93,7 @@ namespace DataStructures.Graphs
         /// <summary>
         /// Get all incoming unweighted edges to a vertex.
         /// </summary>
-        public virtual IEnumerable<WeightedEdge<T>> IncomingEdges(T vertex)
+        public new virtual IEnumerable<WeightedEdge<T, W>> IncomingEdges(T vertex)
         {
             if (!HasVertex(vertex))
                 throw new KeyNotFoundException("Vertex doesn't belong to graph.");
@@ -104,7 +104,7 @@ namespace DataStructures.Graphs
             {
                 if (_vertices[adjacent] != null && _doesEdgeExist(adjacent, source))
                 {
-                    yield return (new WeightedEdge<T>(
+                    yield return (new WeightedEdge<T, W>(
                         (T)_vertices[adjacent],             // from
                         vertex,                             // to
                         _getEdgeWeight(source, adjacent)    // weight
@@ -116,7 +116,7 @@ namespace DataStructures.Graphs
         /// <summary>
         /// Get all outgoing unweighted edges from a vertex.
         /// </summary>
-        public virtual IEnumerable<WeightedEdge<T>> OutgoingEdges(T vertex)
+        public new virtual IEnumerable<WeightedEdge<T, W>> OutgoingEdges(T vertex)
         {
             if (!HasVertex(vertex))
                 throw new KeyNotFoundException("Vertex doesn't belong to graph.");
@@ -127,7 +127,7 @@ namespace DataStructures.Graphs
             {
                 if (_vertices[adjacent] != null && _doesEdgeExist(source, adjacent))
                 {
-                    yield return (new WeightedEdge<T>(
+                    yield return (new WeightedEdge<T, W>(
                         vertex,                             // from
                         (T)_vertices[adjacent],             // to
                         _getEdgeWeight(source, adjacent)    // weight
@@ -149,10 +149,10 @@ namespace DataStructures.Graphs
         /// <summary>
         /// Connects two vertices together with a weight, in the direction: first->second.
         /// </summary>
-        public virtual bool AddEdge(T source, T destination, long weight)
+        public virtual bool AddEdge(T source, T destination, W weight)
         {
             // Return if the weight is equals to the empty edge value
-            if (weight == EMPTY_EDGE_SLOT)
+            if (EMPTY_EDGE_SLOT.Equals(weight))
                 return false;
 
             // Get indices of vertices
@@ -199,10 +199,10 @@ namespace DataStructures.Graphs
         /// <summary>
         /// Updates the edge weight from source to destination.
         /// </summary>
-        public virtual bool UpdateEdgeWeight(T source, T destination, long weight)
+        public virtual bool UpdateEdgeWeight(T source, T destination, W weight)
         {
             // Return if the weight is equals to the empty edge value
-            if (weight == EMPTY_EDGE_SLOT)
+            if (EMPTY_EDGE_SLOT.Equals(weight))
                 return false;
 
             // Get indices of vertices
@@ -271,7 +271,7 @@ namespace DataStructures.Graphs
         /// <summary>
         /// Get edge object from source to destination.
         /// </summary>
-        public virtual WeightedEdge<T> GetEdge(T source, T destination)
+        public virtual WeightedEdge<T, W> GetEdge(T source, T destination)
         {
             // Get indices of vertices
             int srcIndex = _vertices.IndexOf(source);
@@ -283,13 +283,13 @@ namespace DataStructures.Graphs
             if (!_doesEdgeExist(srcIndex, dstIndex))
                 throw new Exception("Edge doesn't exist.");
 
-            return (new WeightedEdge<T>(source, destination, _getEdgeWeight(srcIndex, dstIndex)));
+            return (new WeightedEdge<T, W>(source, destination, _getEdgeWeight(srcIndex, dstIndex)));
         }
 
         /// <summary>
         /// Returns the edge weight from source to destination.
         /// </summary>
-        public virtual long GetEdgeWeight(T source, T destination)
+        public virtual W GetEdgeWeight(T source, T destination)
         {
             return GetEdge(source, destination).Weight;
         }
@@ -297,12 +297,12 @@ namespace DataStructures.Graphs
         /// <summary>
         /// Returns the neighbours of a vertex as a dictionary of nodes-to-weights.
         /// </summary>
-        public virtual Dictionary<T, long> NeighboursMap(T vertex)
+        public virtual Dictionary<T, W> NeighboursMap(T vertex)
         {
             if (!HasVertex(vertex))
                 return null;
 
-            var neighbors = new Dictionary<T, long>();
+            var neighbors = new Dictionary<T, W>();
             int source = _vertices.IndexOf(vertex);
 
             // Check existence of vertex
@@ -351,7 +351,7 @@ namespace DataStructures.Graphs
             _edgesCount = 0;
             _verticesCount = 0;
             _vertices = new ArrayList<object>(_verticesCapacity);
-            _adjacencyMatrix = new long[_verticesCapacity, _verticesCapacity];
+            _adjacencyMatrix = new W[_verticesCapacity, _verticesCapacity];
             _adjacencyMatrix.Populate(rows: _verticesCapacity, columns: _verticesCapacity, defaultValue: EMPTY_EDGE_SLOT);
         }
 

--- a/DataStructures/Graphs/DirectedWeightedSparseGraph.cs
+++ b/DataStructures/Graphs/DirectedWeightedSparseGraph.cs
@@ -18,15 +18,15 @@ using DataStructures.Lists;
 
 namespace DataStructures.Graphs
 {
-    public class DirectedWeightedSparseGraph<T> : IGraph<T>, IWeightedGraph<T> where T : IComparable<T>
+    public class DirectedWeightedSparseGraph<T, W> : IGraph<T, W>, IWeightedGraph<T, W> where T : IComparable<T> where W : IComparable<W>
     {
         /// <summary>
         /// INSTANCE VARIABLES
         /// </summary>
-        private const long EMPTY_EDGE_VALUE = 0;
+        private static readonly W EMPTY_EDGE_VALUE = default(W);
         protected virtual int _edgesCount { get; set; }
         protected virtual T _firstInsertedNode { get; set; }
-        protected virtual Dictionary<T, DLinkedList<WeightedEdge<T>>> _adjacencyList { get; set; }
+        protected virtual Dictionary<T, DLinkedList<WeightedEdge<T, W>>> _adjacencyList { get; set; }
 
 
         /// <summary>
@@ -37,19 +37,19 @@ namespace DataStructures.Graphs
         public DirectedWeightedSparseGraph(uint initialCapacity)
         {
             _edgesCount = 0;
-            _adjacencyList = new Dictionary<T, DLinkedList<WeightedEdge<T>>>((int)initialCapacity);
+            _adjacencyList = new Dictionary<T, DLinkedList<WeightedEdge<T, W>>>((int)initialCapacity);
         }
 
 
         /// <summary>
         /// Helper function. Returns edge object from source to destination, if exists; otherwise, null.
         /// </summary>
-        protected virtual WeightedEdge<T> _tryGetEdge(T source, T destination)
+        protected virtual WeightedEdge<T, W> _tryGetEdge(T source, T destination)
         {
-            WeightedEdge<T> edge = null;
+            WeightedEdge<T, W> edge = null;
 
             // Predicate
-            var sourceToDestinationPredicate = new Predicate<WeightedEdge<T>>((item) => item.Source.IsEqualTo<T>(source) && item.Destination.IsEqualTo<T>(destination));
+            var sourceToDestinationPredicate = new Predicate<WeightedEdge<T, W>>((item) => item.Source.IsEqualTo<T>(source) && item.Destination.IsEqualTo<T>(destination));
 
             // Try to find a match
             if(_adjacencyList.ContainsKey(source))
@@ -72,7 +72,7 @@ namespace DataStructures.Graphs
         /// Helper function. Gets the weight of a directed edge.
         /// Presumes edge does already exist.
         /// </summary>
-        private long _getEdgeWeight(T source, T destination)
+        private W _getEdgeWeight(T source, T destination)
         {
             return _tryGetEdge(source, destination).Weight;
         }
@@ -123,17 +123,17 @@ namespace DataStructures.Graphs
         }
 
 
-        IEnumerable<IEdge<T>> IGraph<T>.Edges
+        IEnumerable<IEdge<T, W>> IGraph<T, W>.Edges
         {
             get { return this.Edges; }
         }
 
-        IEnumerable<IEdge<T>> IGraph<T>.IncomingEdges(T vertex)
+        IEnumerable<IEdge<T, W>> IGraph<T, W>.IncomingEdges(T vertex)
         {
             return this.IncomingEdges(vertex);
         }
 
-        IEnumerable<IEdge<T>> IGraph<T>.OutgoingEdges(T vertex)
+        IEnumerable<IEdge<T, W>> IGraph<T, W>.OutgoingEdges(T vertex)
         {
             return this.OutgoingEdges(vertex);
         }
@@ -142,7 +142,7 @@ namespace DataStructures.Graphs
         /// <summary>
         /// An enumerable collection of all directed weighted edges in graph.
         /// </summary>
-        public virtual IEnumerable<WeightedEdge<T>> Edges
+        public virtual IEnumerable<WeightedEdge<T, W>> Edges
         {
             get
             {
@@ -155,16 +155,16 @@ namespace DataStructures.Graphs
         /// <summary>
         /// Get all incoming directed weighted edges to a vertex.
         /// </summary>
-        public virtual IEnumerable<WeightedEdge<T>> IncomingEdges(T vertex)
+        public virtual IEnumerable<WeightedEdge<T, W>> IncomingEdges(T vertex)
         {
             if (!HasVertex(vertex))
                 throw new KeyNotFoundException("Vertex doesn't belong to graph.");
 
-            var predicate = new Predicate<WeightedEdge<T>>((edge) => edge.Destination.IsEqualTo(vertex));
+            var predicate = new Predicate<WeightedEdge<T, W>>((edge) => edge.Destination.IsEqualTo(vertex));
 
             foreach(var adjacent in _adjacencyList.Keys)
             {
-                WeightedEdge<T> incomingEdge = null;
+                WeightedEdge<T, W> incomingEdge = null;
 
                 if (_adjacencyList[adjacent].TryFindFirst(predicate, out incomingEdge))
                     yield return incomingEdge;
@@ -174,7 +174,7 @@ namespace DataStructures.Graphs
         /// <summary>
         /// Get all outgoing directed weighted edges from a vertex.
         /// </summary>
-        public virtual IEnumerable<WeightedEdge<T>> OutgoingEdges(T vertex)
+        public virtual IEnumerable<WeightedEdge<T, W>> OutgoingEdges(T vertex)
         {
             if (!HasVertex(vertex))
                 throw new KeyNotFoundException("Vertex doesn't belong to graph.");
@@ -196,10 +196,10 @@ namespace DataStructures.Graphs
         /// <summary>
         /// Connects two vertices together with a weight, in the direction: first->second.
         /// </summary>
-        public bool AddEdge(T source, T destination, long weight)
+        public bool AddEdge(T source, T destination, W weight)
         {
             // Check existence of nodes, the validity of the weight value, and the non-existence of edge
-            if (weight == EMPTY_EDGE_VALUE)
+            if (EMPTY_EDGE_VALUE.Equals(weight))
                 return false;
             if (!HasVertex(source) || !HasVertex(destination))
                 return false;
@@ -207,7 +207,7 @@ namespace DataStructures.Graphs
                 return false;
 
             // Add edge from source to destination
-            var edge = new WeightedEdge<T>(source, destination, weight);
+            var edge = new WeightedEdge<T, W>(source, destination, weight);
             _adjacencyList[source].Append(edge);
 
             // Increment edges count
@@ -241,10 +241,10 @@ namespace DataStructures.Graphs
             return true;
         }
 
-        public bool UpdateEdgeWeight(T source, T destination, long weight)
+        public bool UpdateEdgeWeight(T source, T destination, W weight)
         {
             // Check existence of vertices and validity of the weight value
-            if (weight == EMPTY_EDGE_VALUE)
+            if (EMPTY_EDGE_VALUE.Equals(weight))
                 return false;
             if (!HasVertex(source) || !HasVertex(destination))
                 return false;
@@ -264,7 +264,7 @@ namespace DataStructures.Graphs
         /// <summary>
         /// Get edge object from source to destination.
         /// </summary>
-        public virtual WeightedEdge<T> GetEdge(T source, T destination)
+        public virtual WeightedEdge<T, W> GetEdge(T source, T destination)
         {
             if (!HasVertex(source) || !HasVertex(destination))
                 throw new KeyNotFoundException("Either one of the vertices or both of them don't exist.");
@@ -282,7 +282,7 @@ namespace DataStructures.Graphs
         /// <summary>
         /// Returns the edge weight from source to destination.
         /// </summary>
-        public virtual long GetEdgeWeight(T source, T destination)
+        public virtual W GetEdgeWeight(T source, T destination)
         {
             return GetEdge(source, destination).Weight;
         }
@@ -310,7 +310,7 @@ namespace DataStructures.Graphs
             if (_adjacencyList.Count == 0)
                 _firstInsertedNode = vertex;
 
-            _adjacencyList.Add(vertex, new DLinkedList<WeightedEdge<T>>());
+            _adjacencyList.Add(vertex, new DLinkedList<WeightedEdge<T, W>>());
 
             return true;
         }
@@ -383,13 +383,13 @@ namespace DataStructures.Graphs
         /// <summary>
         /// Returns the neighbours of a vertex as a dictionary of nodes-to-weights.
         /// </summary>
-        public Dictionary<T, long> NeighboursMap(T vertex)
+        public Dictionary<T, W> NeighboursMap(T vertex)
         {
             if (!HasVertex(vertex))
                 return null;
 
             var neighbors = _adjacencyList[vertex];
-            var map = new Dictionary<T, long>(neighbors.Count);
+            var map = new Dictionary<T, W>(neighbors.Count);
 
             foreach (var adjacent in neighbors)
                 map.Add(adjacent.Destination, adjacent.Weight);

--- a/DataStructures/Graphs/IEdge.cs
+++ b/DataStructures/Graphs/IEdge.cs
@@ -5,7 +5,7 @@ namespace DataStructures.Graphs
     /// <summary>
     /// This interface should be implemented by all edges classes.
     /// </summary>
-    public interface IEdge<TVertex> : IComparable<IEdge<TVertex>> where TVertex : IComparable<TVertex>
+    public interface IEdge<TVertex, TWeight> : IComparable<IEdge<TVertex, TWeight>> where TVertex : IComparable<TVertex>
     {
         /// <summary>
         /// Gets a value indicating whether this edge is weighted.
@@ -30,7 +30,9 @@ namespace DataStructures.Graphs
         /// Unwighted edges can be thought of as edges of the same weight
         /// </summary>
         /// <value>The weight.</value>
-        Int64 Weight { get; set; }
+        TWeight Weight { get; set; }
     }
+
+    public interface IEdge<TVertex> : IEdge<TVertex, Int64> where TVertex : IComparable<TVertex> { }
 }
 

--- a/DataStructures/Graphs/IGraph.cs
+++ b/DataStructures/Graphs/IGraph.cs
@@ -1,11 +1,11 @@
 ﻿using System;
 using System.Collections.Generic;
-
 using DataStructures.Lists;
+using System.Linq;
 
 namespace DataStructures.Graphs
 {
-    public interface IGraph<T> where T : IComparable<T>
+    public interface IGraph<T, W> where T : IComparable<T>
     {
         /// <summary>
         /// Returns true, if graph is directed; false otherwise.
@@ -35,17 +35,17 @@ namespace DataStructures.Graphs
         /// <summary>
         /// An enumerable collection of edges.
         /// </summary>
-        IEnumerable<IEdge<T>> Edges { get; }
+        IEnumerable<IEdge<T, W>> Edges { get; }
 
         /// <summary>
         /// Get all incoming edges from vertex
         /// </summary>
-        IEnumerable<IEdge<T>> IncomingEdges(T vertex);
+        IEnumerable<IEdge<T, W>> IncomingEdges(T vertex);
 
         /// <summary>
         /// Get all outgoing edges from vertex
         /// </summary>
-        IEnumerable<IEdge<T>> OutgoingEdges(T vertex);
+        IEnumerable<IEdge<T, W>> OutgoingEdges(T vertex);
 
         /// <summary>
         /// Connects two vertices together.
@@ -124,5 +124,6 @@ namespace DataStructures.Graphs
         /// </summary>
         void Clear();
     }
-}
 
+    public interface IGraph<T> : IGraph<T, Int64> where T : IComparable<T> { }
+}

--- a/DataStructures/Graphs/IWeightedGraph.cs
+++ b/DataStructures/Graphs/IWeightedGraph.cs
@@ -5,32 +5,32 @@ namespace DataStructures.Graphs
     /// <summary>
     /// This interface should be implemented alongside the IGraph interface.
     /// </summary>
-    public interface IWeightedGraph<T> where T : IComparable<T>
+    public interface IWeightedGraph<T, W> where T : IComparable<T> where W : IComparable<W>
     {
         /// <summary>
         /// Connects two vertices together with a weight, in the direction: first->second.
         /// </summary>
-        bool AddEdge(T source, T destination, long weight);
+        bool AddEdge(T source, T destination, W weight);
 
         /// <summary>
         /// Updates the edge weight from source to destination.
         /// </summary>
-        bool UpdateEdgeWeight(T source, T destination, long weight);
+        bool UpdateEdgeWeight(T source, T destination, W weight);
 
         /// <summary>
         /// Get edge object from source to destination.
         /// </summary>
-        WeightedEdge<T> GetEdge(T source, T destination);
+        WeightedEdge<T, W> GetEdge(T source, T destination);
 
         /// <summary>
         /// Returns the edge weight from source to destination.
         /// </summary>
-        long GetEdgeWeight(T source, T destination);
+        W GetEdgeWeight(T source, T destination);
 
         /// <summary>
         /// Returns the neighbours of a vertex as a dictionary of nodes-to-weights.
         /// </summary>
-        System.Collections.Generic.Dictionary<T, long> NeighboursMap(T vertex);
+        System.Collections.Generic.Dictionary<T, W> NeighboursMap(T vertex);
     }
 }
 

--- a/DataStructures/Graphs/UndirectedDenseGraph.cs
+++ b/DataStructures/Graphs/UndirectedDenseGraph.cs
@@ -108,17 +108,17 @@ namespace DataStructures.Graphs
         }
 
 
-        IEnumerable<IEdge<T>> IGraph<T>.Edges
+        IEnumerable<IEdge<T, Int64>> IGraph<T, Int64>.Edges
         {
             get { return this.Edges; }
         }
 
-        IEnumerable<IEdge<T>> IGraph<T>.IncomingEdges(T vertex)
+        IEnumerable<IEdge<T, Int64>> IGraph<T, Int64>.IncomingEdges(T vertex)
         {
             return this.IncomingEdges(vertex);
         }
 
-        IEnumerable<IEdge<T>> IGraph<T>.OutgoingEdges(T vertex)
+        IEnumerable<IEdge<T, Int64>> IGraph<T, Int64>.OutgoingEdges(T vertex)
         {
             return this.OutgoingEdges(vertex);
         }

--- a/DataStructures/Graphs/UndirectedSparseGraph.cs
+++ b/DataStructures/Graphs/UndirectedSparseGraph.cs
@@ -93,17 +93,17 @@ namespace DataStructures.Graphs
         }
 
 
-        IEnumerable<IEdge<T>> IGraph<T>.Edges
+        IEnumerable<IEdge<T, Int64>> IGraph<T, Int64>.Edges
         {
             get { return this.Edges; }
         }
 
-        IEnumerable<IEdge<T>> IGraph<T>.IncomingEdges(T vertex)
+        IEnumerable<IEdge<T, Int64>> IGraph<T, Int64>.IncomingEdges(T vertex)
         {
             return this.IncomingEdges(vertex);
         }
 
-        IEnumerable<IEdge<T>> IGraph<T>.OutgoingEdges(T vertex)
+        IEnumerable<IEdge<T, Int64>> IGraph<T, Int64>.OutgoingEdges(T vertex)
         {
             return this.OutgoingEdges(vertex);
         }

--- a/DataStructures/Graphs/UndirectedWeightedSparseGraph.cs
+++ b/DataStructures/Graphs/UndirectedWeightedSparseGraph.cs
@@ -17,15 +17,15 @@ using DataStructures.Lists;
 
 namespace DataStructures.Graphs
 {
-    public class UndirectedWeightedSparseGraph<T> : IGraph<T>, IWeightedGraph<T> where T : IComparable<T>
+    public class UndirectedWeightedSparseGraph<T, W> : IGraph<T, W>, IWeightedGraph<T, W> where T : IComparable<T> where W : IComparable<W>
     {
         /// <summary>
         /// INSTANCE VARIABLES
         /// </summary>
-        private const long EMPTY_EDGE_VALUE = 0;
+        private static readonly W EMPTY_EDGE_VALUE = default(W);
         protected virtual int _edgesCount { get; set; }
         protected virtual T _firstInsertedNode { get; set; }
-        protected virtual Dictionary<T, DLinkedList<WeightedEdge<T>>> _adjacencyList { get; set; }
+        protected virtual Dictionary<T, DLinkedList<WeightedEdge<T, W>>> _adjacencyList { get; set; }
 
 
         /// <summary>
@@ -36,20 +36,20 @@ namespace DataStructures.Graphs
         public UndirectedWeightedSparseGraph(uint initialCapacity)
         {
             _edgesCount = 0;
-            _adjacencyList = new Dictionary<T, DLinkedList<WeightedEdge<T>>>((int)initialCapacity);
+            _adjacencyList = new Dictionary<T, DLinkedList<WeightedEdge<T, W>>>((int)initialCapacity);
         }
 
 
         /// <summary>
         /// Helper function. Returns edge object from source to destination, if exists; otherwise, null.
         /// </summary>
-        protected virtual WeightedEdge<T> _tryGetEdge(T source, T destination)
+        protected virtual WeightedEdge<T, W> _tryGetEdge(T source, T destination)
         {
             var success = false;
-            WeightedEdge<T> edge = null;
+            WeightedEdge<T, W> edge = null;
 
-            var sourceToDestinationPredicate = new Predicate<WeightedEdge<T>>((item) => item.Source.IsEqualTo<T>(source) && item.Destination.IsEqualTo<T>(destination));
-            var destinationToSourcePredicate = new Predicate<WeightedEdge<T>>((item) => item.Source.IsEqualTo<T>(destination) && item.Destination.IsEqualTo<T>(source));
+            var sourceToDestinationPredicate = new Predicate<WeightedEdge<T, W>>((item) => item.Source.IsEqualTo<T>(source) && item.Destination.IsEqualTo<T>(destination));
+            var destinationToSourcePredicate = new Predicate<WeightedEdge<T, W>>((item) => item.Source.IsEqualTo<T>(destination) && item.Destination.IsEqualTo<T>(source));
 
             if(_adjacencyList.ContainsKey(source))
                 success = _adjacencyList[source].TryFindFirst(sourceToDestinationPredicate, out edge);
@@ -73,7 +73,7 @@ namespace DataStructures.Graphs
         /// Helper function. Gets the weight of a undirected edge.
         /// Presumes edge does already exist.
         /// </summary>
-        private long _getEdgeWeight(T source, T destination)
+        private W _getEdgeWeight(T source, T destination)
         {
             return _tryGetEdge(source, destination).Weight;
         }
@@ -124,17 +124,17 @@ namespace DataStructures.Graphs
         }
 
 
-        IEnumerable<IEdge<T>> IGraph<T>.Edges
+        IEnumerable<IEdge<T, W>> IGraph<T, W>.Edges
         {
             get { return this.Edges; }
         }
 
-        IEnumerable<IEdge<T>> IGraph<T>.IncomingEdges(T vertex)
+        IEnumerable<IEdge<T, W>> IGraph<T, W>.IncomingEdges(T vertex)
         {
             return this.IncomingEdges(vertex);
         }
 
-        IEnumerable<IEdge<T>> IGraph<T>.OutgoingEdges(T vertex)
+        IEnumerable<IEdge<T, W>> IGraph<T, W>.OutgoingEdges(T vertex)
         {
             return this.OutgoingEdges(vertex);
         }
@@ -143,7 +143,7 @@ namespace DataStructures.Graphs
         /// <summary>
         /// An enumerable collection of all weighted edges in Graph.
         /// </summary>
-        public virtual IEnumerable<WeightedEdge<T>> Edges
+        public virtual IEnumerable<WeightedEdge<T, W>> Edges
         {
             get
             {
@@ -169,19 +169,19 @@ namespace DataStructures.Graphs
         /// <summary>
         /// Get all incoming weighted edges to a vertex
         /// </summary>
-        public virtual IEnumerable<WeightedEdge<T>> IncomingEdges(T vertex)
+        public virtual IEnumerable<WeightedEdge<T, W>> IncomingEdges(T vertex)
         {
             if (!HasVertex(vertex))
                 throw new KeyNotFoundException("Vertex doesn't belong to graph.");
             
             foreach(var edge in _adjacencyList[vertex])
-                yield return (new WeightedEdge<T>(edge.Destination, edge.Source, edge.Weight));
+                yield return (new WeightedEdge<T, W>(edge.Destination, edge.Source, edge.Weight));
         }
 
         /// <summary>
         /// Get all outgoing weighted edges from a vertex.
         /// </summary>
-        public virtual IEnumerable<WeightedEdge<T>> OutgoingEdges(T vertex)
+        public virtual IEnumerable<WeightedEdge<T, W>> OutgoingEdges(T vertex)
         {
             if (!HasVertex(vertex))
                 throw new KeyNotFoundException("Vertex doesn't belong to graph.");
@@ -203,10 +203,10 @@ namespace DataStructures.Graphs
         /// <summary>
         /// Connects two vertices together with a weight, in the direction: first->second.
         /// </summary>
-        public bool AddEdge(T source, T destination, long weight)
+        public bool AddEdge(T source, T destination, W weight)
         {
             // Check existence of nodes, the validity of the weight value, and the non-existence of edge
-            if (weight == EMPTY_EDGE_VALUE)
+            if (EMPTY_EDGE_VALUE.Equals(weight))
                 return false;
             if (!HasVertex(source) || !HasVertex(destination))
                 return false;
@@ -214,8 +214,8 @@ namespace DataStructures.Graphs
                 return false;
 
             // Add edge from source to destination
-            var sourceDdge = new WeightedEdge<T>(source, destination, weight);
-            var destinationEdge = new WeightedEdge<T>(destination, source, weight);
+            var sourceDdge = new WeightedEdge<T, W>(source, destination, weight);
+            var destinationEdge = new WeightedEdge<T, W>(destination, source, weight);
 
             _adjacencyList[source].Append(sourceDdge);
             _adjacencyList[destination].Append(destinationEdge);
@@ -235,12 +235,12 @@ namespace DataStructures.Graphs
             if (!HasVertex(source) || !HasVertex(destination))
                 return false;
 
-            WeightedEdge<T> edge1, edge2;
+            WeightedEdge<T, W> edge1, edge2;
 
-            var sourceToDestinationPredicate = new Predicate<WeightedEdge<T>>((item) => item.Source.IsEqualTo<T>(source) && item.Destination.IsEqualTo<T>(destination));
+            var sourceToDestinationPredicate = new Predicate<WeightedEdge<T, W>>((item) => item.Source.IsEqualTo<T>(source) && item.Destination.IsEqualTo<T>(destination));
             _adjacencyList[source].TryFindFirst(sourceToDestinationPredicate, out edge1);
 
-            var destinationToSourcePredicate = new Predicate<WeightedEdge<T>>((item) => item.Source.IsEqualTo<T>(destination) && item.Destination.IsEqualTo<T>(source));
+            var destinationToSourcePredicate = new Predicate<WeightedEdge<T, W>>((item) => item.Source.IsEqualTo<T>(destination) && item.Destination.IsEqualTo<T>(source));
             _adjacencyList[destination].TryFindFirst(destinationToSourcePredicate, out edge2);
 
             // If edge doesn't exist, return false
@@ -261,10 +261,10 @@ namespace DataStructures.Graphs
             return true;
         }
 
-        public bool UpdateEdgeWeight(T source, T destination, long weight)
+        public bool UpdateEdgeWeight(T source, T destination, W weight)
         {
             // Check existence of vertices and validity of the weight value
-            if (weight == EMPTY_EDGE_VALUE)
+            if (EMPTY_EDGE_VALUE.Equals(weight))
                 return false;
             if (!HasVertex(source) || !HasVertex(destination))
                 return false;
@@ -300,7 +300,7 @@ namespace DataStructures.Graphs
         /// <summary>
         /// Get edge object from source to destination.
         /// </summary>
-        public virtual WeightedEdge<T> GetEdge(T source, T destination)
+        public virtual WeightedEdge<T, W> GetEdge(T source, T destination)
         {
             if (!HasVertex(source) || !HasVertex(destination))
                 throw new KeyNotFoundException("Either one of the vertices or both of them don't exist.");
@@ -318,7 +318,7 @@ namespace DataStructures.Graphs
         /// <summary>
         /// Returns the edge weight from source to destination.
         /// </summary>
-        public virtual long GetEdgeWeight(T source, T destination)
+        public virtual W GetEdgeWeight(T source, T destination)
         {
             return GetEdge(source, destination).Weight;
         }
@@ -346,7 +346,7 @@ namespace DataStructures.Graphs
             if (_adjacencyList.Count == 0)
                 _firstInsertedNode = vertex;
 
-            _adjacencyList.Add(vertex, new DLinkedList<WeightedEdge<T>>());
+            _adjacencyList.Add(vertex, new DLinkedList<WeightedEdge<T, W>>());
 
             return true;
         }
@@ -414,13 +414,13 @@ namespace DataStructures.Graphs
         /// <summary>
         /// Returns the neighbours of a vertex as a dictionary of nodes-to-weights.
         /// </summary>
-        public Dictionary<T, long> NeighboursMap(T vertex)
+        public Dictionary<T, W> NeighboursMap(T vertex)
         {
             if (!HasVertex(vertex))
                 return null;
 
             var neighbors = _adjacencyList[vertex];
-            var map = new Dictionary<T, long>(neighbors.Count);
+            var map = new Dictionary<T, W>(neighbors.Count);
 
             foreach (var adjacent in neighbors)
                 map.Add(adjacent.Destination, adjacent.Weight);

--- a/DataStructures/Graphs/UnweightedEdge.cs
+++ b/DataStructures/Graphs/UnweightedEdge.cs
@@ -53,7 +53,7 @@ namespace DataStructures.Graphs
 
 
         #region IComparable implementation
-        public int CompareTo(IEdge<TVertex> other)
+        public int CompareTo(IEdge<TVertex, Int64> other)
         {
             if (other == null)
                 return -1;

--- a/DataStructures/Graphs/WeightedEdge.cs
+++ b/DataStructures/Graphs/WeightedEdge.cs
@@ -7,7 +7,9 @@ namespace DataStructures.Graphs
     /// <summary>
     /// The graph weighted edge class.
     /// </summary>
-    public class WeightedEdge<TVertex> : IEdge<TVertex> where TVertex : IComparable<TVertex>
+    public class WeightedEdge<TVertex, TWeight> : IEdge<TVertex, TWeight>
+        where TVertex : IComparable<TVertex>
+        where TWeight : IComparable<TWeight>
     {
         /// <summary>
         /// Gets or sets the source.
@@ -25,7 +27,7 @@ namespace DataStructures.Graphs
         /// Gets or sets the weight of edge.
         /// </summary>
         /// <value>The weight.</value>
-        public Int64 Weight { get; set; }
+        public TWeight Weight { get; set; }
 
         /// <summary>
         /// Gets a value indicating whether this edge is weighted.
@@ -39,7 +41,7 @@ namespace DataStructures.Graphs
         /// <summary>
         /// CONSTRUCTOR
         /// </summary>
-        public WeightedEdge(TVertex src, TVertex dst, Int64 weight)
+        public WeightedEdge(TVertex src, TVertex dst, TWeight weight)
         {
             Source = src;
             Destination = dst;
@@ -48,7 +50,7 @@ namespace DataStructures.Graphs
 
 
         #region IComparable implementation
-        public int CompareTo(IEdge<TVertex> other)
+        public int CompareTo(IEdge<TVertex, TWeight> other)
         {
             if (other == null)
                 return -1;


### PR DESCRIPTION
Original implementation only supports `long` as edge weights.
This PR allows customized edge weight types while keeps default edge weight type as long/Int64.