### PR TITLE
Basic optimizations for UndirectedSparseGraph

### DIFF
--- a/DataStructures/Graphs/UndirectedSparseGraph.cs
+++ b/DataStructures/Graphs/UndirectedSparseGraph.cs
@@ -236,18 +236,15 @@ namespace DataStructures.Graphs
             if (!_adjacencyList.ContainsKey(vertex))
                 return false;
 
-            _adjacencyList.Remove(vertex);
-
-            foreach (var adjacent in _adjacencyList)
+            var neighbors = Neighbours(vertex);
+            foreach (var neighbor in neighbors)
             {
-                if (adjacent.Value.Contains(vertex))
-                {
-                    adjacent.Value.Remove(vertex);
-
-                    // Decrement the edges count.
-                    --_edgesCount;
-                }
+                _adjacencyList[neighbor].Remove(vertex);
             }
+
+            _edgesCount -= neighbors.Count;
+
+            _adjacencyList.Remove(vertex);
 
             return true;
         }

--- a/DataStructures/Lists/DLinkedList.cs
+++ b/DataStructures/Lists/DLinkedList.cs
@@ -557,14 +557,7 @@ namespace DataStructures.Lists
         /// <returns>True if found; false otherwise.</returns>
         public virtual bool Contains(T dataItem)
         {
-            try
-            {
-                return Find(dataItem).IsEqualTo(dataItem);
-            }
-            catch (Exception)
-            {
-                return false;
-            }
+            return TryFind(dataItem, out var found) && found.IsEqualTo(dataItem);
         }
 
         /// <summary>
@@ -587,6 +580,33 @@ namespace DataStructures.Lists
             }
 
             throw new Exception("Item was not found.");
+        }
+
+        /// <summary>
+        /// Tries to find the specified item in the list.
+        /// </summary>
+        /// <param name="dataItem">Value to find.</param>
+        /// <param name="found">Value if found, default otherwise.</param>
+        /// <returns>value.</returns>
+        public virtual bool TryFind(T dataItem, out T found)
+        {
+            found = default;
+
+            if (IsEmpty()) return false;
+
+            var currentNode = _firstNode;
+            while (currentNode != null)
+            {
+                if (currentNode.Data.IsEqualTo(dataItem))
+                {
+                    found = dataItem;
+                    return true;
+                }
+
+                currentNode = currentNode.Next;
+            }
+
+            return false;
         }
 
         /// <summary>


### PR DESCRIPTION
### Description

Optimized item removal from UndirectedSparseGraph by only trying to remove the given item from its neighbors' adjacency lists, instead of all vertices'.

Optimized the Contains function of the DLinkedList structure by avoiding exceptions entirely, as they are costly and not really meaningful in this case (not finding an item in a list is normal, it's not an exception).

### Checklist

- [ ] An issue was first created **before** opening this pull request
- [ ] The new code follows the [contribution guidelines](CONTRIBUTING.md)
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests to ensure that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes

