### PR TITLE
Issue 46: Switch netcoreapp2 to netstandard2 for libraries. …

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -161,6 +161,7 @@ ClientBin/
 *.pfx
 *.publishsettings
 node_modules/
+*.nupkg
 
 # RIA/Silverlight projects
 Generated_Code/

--- a/Algorithms/Algorithms.csproj
+++ b/Algorithms/Algorithms.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>    
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Algorithms/Numeric/SieveOfAtkin.cs
+++ b/Algorithms/Numeric/SieveOfAtkin.cs
@@ -1,5 +1,4 @@
 ﻿using System.Collections.Generic;
-using System.Reflection.Metadata.Ecma335;
 using System.Threading.Tasks;
 
 /***

--- a/DataStructures/Common/PrimesList.cs
+++ b/DataStructures/Common/PrimesList.cs
@@ -225,7 +225,7 @@ namespace DataStructures.Common
 	        {
 		        using (var stream = typeof(PrimesList).GetTypeInfo().Assembly.GetManifestResourceStream(resourceName))
 		        using (var reader = new StreamReader(stream ?? throw new InvalidOperationException("Failed to read resource"), Encoding.UTF8))
-			        return reader.ReadToEnd().Split("\n");
+			        return reader.ReadToEnd().Split('\n');
 	        }
 	        catch (Exception ex)
 	        {

--- a/DataStructures/DataStructures.csproj
+++ b/DataStructures/DataStructures.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>    
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
   
   <ItemGroup>

--- a/Nuget/c-sharp-algorithms.nuspec
+++ b/Nuget/c-sharp-algorithms.nuspec
@@ -11,6 +11,9 @@
     <projectUrl>https://github.com/aalhour/C-Sharp-Algorithms</projectUrl>
     <icon>images\icon.png</icon>
     <description>Plug-and-play class-library project of standard Data Structures and Algorithms in C#.</description>
+    <dependencies>
+	  <group targetFramework=".NETStandard2.0" />
+    </dependencies>
   </metadata>
   	<files>
 		<file src="..\Algorithms\bin\Release\**\*.*" target="lib" />


### PR DESCRIPTION
### Description

Update for issue 46:
Switch netcoreapp2 to netstandard2 for libraries.
Removed unused using that would have required netcoreapp3.1 to compile.
Fixed string to char because netstd2 didn't allow for strings as char arrays.
Added .NETStandard2.0 dependency to nuspec.

### Checklist

- [X] An issue was first created **before** opening this pull request
- [X] The new code follows the [contribution guidelines](CONTRIBUTING.md)
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests to ensure that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes

