### PR TITLE
Issue 129: Return primes list as read-only.

### DIFF
--- a/DataStructures/Common/PrimesList.cs
+++ b/DataStructures/Common/PrimesList.cs
@@ -184,11 +184,11 @@ namespace DataStructures.Common
         }
 
         /// <summary>
-        /// Returns the list of primes
+        /// Returns the read-only IList of primes
         /// </summary>
-        public List<int> GetAll
+        public IList<int> GetAll
         {
-            get { return _primes; }
+            get { return _primes.AsReadOnly(); }
         }
 
         /// <summary>

--- a/UnitTest/DataStructuresTests/PrimeListTest.cs
+++ b/UnitTest/DataStructuresTests/PrimeListTest.cs
@@ -1,4 +1,5 @@
-﻿using DataStructures.Common;
+﻿using System;
+using DataStructures.Common;
 using Xunit;
 
 namespace UnitTest.DataStructuresTests
@@ -10,6 +11,14 @@ namespace UnitTest.DataStructuresTests
         {
             var instance = PrimesList.Instance;
             Assert.Equal(10000, instance.Count);
+        }
+
+        [Fact]
+        public void PrimesListIsReadOnly()
+        {
+            var instance = PrimesList.Instance;
+            NotSupportedException ex = Assert.Throws<NotSupportedException>(() => instance.GetAll[0] = -1);
+            Assert.Equal("Collection is read-only.", ex.Message);
         }
     }
 }


### PR DESCRIPTION
### Description

Alter GetAll to return a read-only IList<int> of the prime numbers.

### Checklist

- [X] An issue was first created **before** opening this pull request
- [X] The new code follows the [contribution guidelines](CONTRIBUTING.md)
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests to ensure that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes

