### PR TITLE
Fixed Issue #137 Items are not always added to a SkipList

### DIFF
--- a/DataStructures/Lists/SkipList.cs
+++ b/DataStructures/Lists/SkipList.cs
@@ -28,22 +28,6 @@ namespace DataStructures.Lists
         private readonly int MaxLevel = 32;
         private readonly double Probability = 0.5;
 
-
-        /// <summary>
-        /// Private helper. Used in Add method.
-        /// </summary>
-        /// <returns></returns>
-        private int _getNextLevel()
-        {
-            int lvl = 0;
-
-            while (_randomizer.NextDouble() < Probability && lvl <= _currentMaxLevel && lvl < MaxLevel)
-                ++lvl;
-
-            return lvl;
-        }
-
-
         /// <summary>
         /// CONSTRUCTOR
         /// </summary>
@@ -94,12 +78,15 @@ namespace DataStructures.Lists
         /// <summary>
         /// Access elements by index
         /// </summary>
-        public T this[int index]
+        public T this[T item]
         {
             get
             {
-                // TODO:
-                throw new NotImplementedException();
+                return Find(item, out var result) ? result : throw new KeyNotFoundException();
+            }
+            set
+            {
+                Add(item);
             }
         }
 
@@ -118,8 +105,6 @@ namespace DataStructures.Lists
 
                 toBeUpdated[i] = current;
             }
-
-            current = current.Forwards[0];
 
             // Get the next node level, and update list level if required.
             int lvl = _getNextLevel();
@@ -150,8 +135,7 @@ namespace DataStructures.Lists
         /// </summary>
         public bool Remove(T item)
         {
-            T deleted;
-            return Remove(item, out deleted);
+            return Remove(item, out var _);
         }
 
         /// <summary>
@@ -185,8 +169,12 @@ namespace DataStructures.Lists
             // We know that the node is in the list.
             // Unlink it from the levels where it exists.
             for (int i = 0; i < _currentMaxLevel; ++i)
+            {
                 if (toBeUpdated[i].Forwards[i] == current)
+                {
                     toBeUpdated[i].Forwards[i] = current.Forwards[i];
+                }
+            }
 
             // Decrement the count
             --_count;
@@ -367,6 +355,19 @@ namespace DataStructures.Lists
         }
         #endregion
 
+        /// <summary>
+        /// Private helper. Used in Add method.
+        /// </summary>
+        /// <returns></returns>
+        private int _getNextLevel()
+        {
+            int lvl = 1;
+
+            while (_randomizer.NextDouble() < Probability && lvl <= _currentMaxLevel && lvl < MaxLevel)
+                ++lvl;
+
+            return lvl;
+        }
     }
 
 }

--- a/DataStructures/Lists/SkipListNode.cs
+++ b/DataStructures/Lists/SkipListNode.cs
@@ -5,12 +5,6 @@ namespace DataStructures.Lists
     public class SkipListNode<T> : IComparable<SkipListNode<T>> where T : IComparable<T>
     {
         /// <summary>
-        /// Instance variables
-        /// </summary>
-        private T _value;
-        private SkipListNode<T>[] _forwards;
-
-        /// <summary>
         /// CONSTRUCTORS
         /// </summary>
         public SkipListNode(T value, int level)
@@ -25,20 +19,12 @@ namespace DataStructures.Lists
         /// <summary>
         /// Get and set node's value
         /// </summary>
-        public virtual T Value
-        {
-            get { return this._value; }
-            private set { this._value = value; }
-        }
+        public virtual T Value { get; private set; }
 
         /// <summary>
         /// Get and set node's forwards links
         /// </summary>
-        public virtual SkipListNode<T>[] Forwards
-        {
-            get { return this._forwards; }
-            private set { this._forwards = value; }
-        }
+        public virtual SkipListNode<T>[] Forwards { get; private set; }
 
         /// <summary>
         /// Return level of node.
@@ -55,7 +41,7 @@ namespace DataStructures.Lists
         {
             if (other == null)
                 return -1;
-
+            
             return this.Value.CompareTo(other.Value);
         }
     }

--- a/UnitTest/DataStructuresTests/SkipListTest.cs
+++ b/UnitTest/DataStructuresTests/SkipListTest.cs
@@ -1,4 +1,5 @@
-﻿using DataStructures.Lists;
+﻿using System.Collections.Generic;
+using DataStructures.Lists;
 using Xunit;
 
 namespace UnitTest.DataStructuresTests
@@ -6,30 +7,86 @@ namespace UnitTest.DataStructuresTests
     public static class SkipListTest
     {
         [Fact]
-        public static void DoTest()
+        public static void AddOneElement()
         {
             var skipList = new SkipList<int>();
 
-            for (int i = 100; i >= 50; --i)
+            skipList.Add(10);
+
+            Assert.True(skipList.Count == 1);
+            Assert.Contains(10, skipList);
+        }
+
+        [Fact]
+        public static void AddBatchOfElements()
+        {
+            var skipList = new SkipList<int>();
+
+            for (int i = 100; i > 50; --i)
+            {
                 skipList.Add(i);
+            }
 
-            for (int i = 0; i <= 35; ++i)
+            Assert.True(skipList.Count == 50);
+            for (int i = 100; i > 50; --i)
+            {
+                Assert.Contains(i, skipList);
+            }
+        }
+
+        [Fact]
+        public static void AddThreeElementsRemoveOneElement()
+        {
+            var skipList = new SkipList<int>();
+
+            skipList.Add(1);
+            skipList.Add(2);
+            skipList.Add(3);
+            skipList.Remove(2);
+
+            Assert.True(skipList.Count == 2);
+            Assert.Contains(1, skipList);
+            Assert.Contains(3, skipList);
+            Assert.DoesNotContain(2, skipList);
+        }
+
+        [Fact]
+        public static void AddAndRemoveBatchOfElements()
+        {
+            var skipList = new SkipList<int>();
+
+            for (int i = 100; i > 50; --i)
+            {
                 skipList.Add(i);
+            }
 
-            for (int i = -15; i <= 0; ++i)
-                skipList.Add(i);
+            for (int i = 100; i > 50; --i)
+            {
+                skipList.Remove(i);
+            }
 
-            for (int i = -15; i >= -35; --i)
-                skipList.Add(i);
+            Assert.True(skipList.Count == 0);
+            for (int i = 100; i > 50; --i)
+            {
+                Assert.DoesNotContain(i, skipList);
+            }
+        }
 
-            Assert.True(skipList.Count == 124);
+        [Fact]
+        public static void ClearList()
+        {
+            var skipList = new SkipList<int>();
 
+            skipList.Add(1);
+            skipList.Add(2);
+            skipList.Add(3);
             skipList.Clear();
 
-            for (int i = 100; i >= 0; --i)
-                skipList.Add(i);
-
-            Assert.True(skipList.Count == 101);
+            Assert.True(skipList.Count == 0);
+            Assert.True(skipList.IsEmpty);
+            Assert.DoesNotContain(1, skipList);
+            Assert.DoesNotContain(2, skipList);
+            Assert.DoesNotContain(3, skipList);
         }
     }
 }


### PR DESCRIPTION
### Description

Fix #137 . This bug occurs when _getNextLevel() method returned 0.

I divided a unit test for SkipList on some tests. And added additinal tests.

I add implementaion for public T this[T item]. I think this should be work like a standard Dictionary type.

### Checklist

- [ ] An issue (#137 ) was first created **before** opening this pull request
- [ ] The new code follows the [contribution guidelines](CONTRIBUTING.md)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests to ensure that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

