### PR TITLE
Fixed #155 Fixed bad implement, bad data structure CircularBuffer

### DIFF
--- a/DataStructures/Lists/CircularBuffer.cs
+++ b/DataStructures/Lists/CircularBuffer.cs
@@ -3,9 +3,9 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 
-namespace DataStructures.Lists 
+namespace DataStructures.Lists
 {
-    public class CircularBuffer<T> : IEnumerable<T>, ICollection<T> where T : IComparable<T> 
+    public class CircularBuffer<T> : ICollection<T>
     {
         private T[] _circularBuffer;
         private int _end;
@@ -15,40 +15,22 @@ namespace DataStructures.Lists
         /// <summary>
         /// Returns the length of the buffer
         /// </summary>
-        public int Length 
-        {
-            get 
-            {
-                return _circularBuffer.Length - 1;
-            }
-        }
+        public int Length => _circularBuffer.Length;
 
         /// <summary>
         ///  Checks if no element is inserted into the buffer
         /// </summary>
-        public bool IsEmpty 
-        {
-            get 
-            {
-                return _count == 0;
-            }
-        }
+        public bool IsEmpty => _count == 0;
 
         /// <summary>
         /// Checks if the buffer is filled up
         /// </summary>
-        public bool IsFilledUp 
-        {
-            get 
-            {
-                return ((_end + 1) % _circularBuffer.Length == _start) && !_circularBuffer[_start].Equals(_circularBuffer[_end]);
-            }
-        }
+        public bool IsFilledUp => Count == Length;
 
         /// <summary>
         /// Controls whether data should be overridden when it is continously inserted without reading
         /// </summary>
-        public bool CanOverride 
+        public bool CanOverride
         {
             get;
         }
@@ -56,7 +38,7 @@ namespace DataStructures.Lists
         /// <summary>
         /// Initializes a circular buffer with initial length of 10
         /// </summary>
-        public CircularBuffer(bool canOverride = true) : this(_defaultBufferLength, canOverride) 
+        public CircularBuffer(bool canOverride = true) : this(_defaultBufferLength, canOverride)
         {
         }
 
@@ -64,13 +46,13 @@ namespace DataStructures.Lists
         /// Initializes a circular buffer with given length
         /// </summary>
         /// <param name="length">The length of the buffer</param>
-        public CircularBuffer(int length, bool canOverride = true) 
+        public CircularBuffer(int length, bool canOverride = true)
         {
-            if (length < 1) 
+            if (length < 1)
             {
                 throw new ArgumentOutOfRangeException("length can not be zero or negative");
             }
-            _circularBuffer = new T[length + 1];
+            _circularBuffer = new T[length];
             _end = 0;
             _start = 0;
             CanOverride = canOverride;
@@ -80,52 +62,79 @@ namespace DataStructures.Lists
         /// Writes value to the back of the buffer
         /// </summary>
         /// <param name="value">value to be added to the buffer</param>
-        public void Add(T value) 
+        public void Add(T value)
         {
-            if (CanOverride==false && IsFilledUp==true) 
+            if (CanOverride == false && IsFilledUp == true)
             {
                 throw new CircularBufferFullException($"Circular Buffer is filled up. {value} can not be inserted");
             }
-            innerInsert(value);
+            InnerInsert(value);
         }
 
         // Inserts data into the buffer without checking if it is full
-        private void innerInsert(T value) 
+        private void InnerInsert(T value)
         {
             _circularBuffer[_end] = value;
-            _end = (_end + 1) % _circularBuffer.Length;
-            if (_end == _start) 
+            _end = (_end + 1) % Length;
+            if (IsFilledUp)
             {
-                _start = (_start + 1) % _circularBuffer.Length;
+                _start = _end;
             }
-
-            // Count should not be greater than the length of the buffer when overriding 
-            _count = _count < Length ? ++_count : _count;
+            else
+            {
+                ++_count;
+            }
         }
 
         /// <summary>
         ///     Reads and removes the value in front of the buffer, and places the next value in front.
         /// </summary>
-        public T Pop() 
+        public T Pop()
         {
+            if (IsEmpty)
+            {
+                throw new InvalidOperationException("The Circular Buffer is empty");
+            }
+
             var result = _circularBuffer[_start];
-            _circularBuffer[_start] = _circularBuffer[_end];
-            _start = (_start + 1) % _circularBuffer.Length;
-            //Count should not go below Zero when poping an empty buffer.
-            _count = _count > 0 ? --_count : _count;
+            _circularBuffer[_start] = default;
+            _start = (_start + 1) % Length;
+            --_count;
             return result;
         }
 
+
+
+
+
         #region IEnumerable Implementation
-        public IEnumerator<T> GetEnumerator() 
+        public IEnumerator<T> GetEnumerator()
         {
-            for (int i = _start; i < Count; i++) 
+            if (!IsEmpty)
             {
-                yield return _circularBuffer[i];
+                if (_start < _end)
+                {
+                    for (int i = _start; i < _end; i++)
+                    {
+                        yield return _circularBuffer[i];
+                    }
+                }
+                else
+                {
+                    for (int i = _start; i < _circularBuffer.Length; i++)
+                    {
+                        yield return _circularBuffer[i];
+                    }
+
+                    for (int i = 0; i < _end; i++)
+                    {
+                        yield return _circularBuffer[i];
+                    }
+                }
             }
         }
 
-        IEnumerator IEnumerable.GetEnumerator() 
+        IEnumerator IEnumerable.GetEnumerator()
         {
             return GetEnumerator();
         }
@@ -136,51 +145,106 @@ namespace DataStructures.Lists
         /// <summary>
         /// Returns the number of elements.
         /// </summary>
-        public int Count 
-        {
-            get 
-            {
-                return _count;
-            }
-        }
+        public int Count => _count;
         /// <summary>
         /// Checks whether this collection is readonly
         /// </summary>
-        public bool IsReadOnly 
-        {
-            get 
-            {
-                return false;
-            }
-        }
+        public bool IsReadOnly => false;
         /// <summary>
         /// Clears this instance
         /// </summary>
-        public void Clear() 
+        public void Clear()
         {
             _count = 0;
             _start = 0;
             _end = 0;
-            _circularBuffer = new T[Length + 1];
+            Array.Clear(_circularBuffer, 0, _circularBuffer.Length);
         }
         /// <summary>
         /// Checks whether the buffer contains an item
         /// </summary>
-        public bool Contains(T item) 
+        public bool Contains(T item)
         {
-            return _circularBuffer.Contains(item);
+            if (IsEmpty)
+            {
+                return false;
+            }
+            else if (_start < _end)
+            {
+                if (item == null)
+                {
+                    for (int i = _start; i < _end; i++)
+                    {
+                        if (_circularBuffer[i] == null)
+                        {
+                            return true;
+                        }
+                    }
+                }
+                else
+                {
+                    for (int i = _start; i < _end; i++)
+                    {
+                        if (_circularBuffer[i] != null && _circularBuffer[i].Equals(item))
+                        {
+                            return true;
+                        }
+                    }
+                }
+            }
+            else
+            {
+                if (item == null)
+                {
+                    for (int i = _start; i < _circularBuffer.Length; i++)
+                    {
+                        if (_circularBuffer[i] == null)
+                        {
+                            return true;
+                        }
+                    }
+
+                    for (int i = 0; i < _end; i++)
+                    {
+                        if (_circularBuffer[i] == null)
+                        {
+                            return true;
+                        }
+                    }
+                }
+                else
+                {
+                    for (int i = _start; i < _circularBuffer.Length; i++)
+                    {
+                        if (_circularBuffer[i] != null && _circularBuffer[i].Equals(item))
+                        {
+                            return true;
+                        }
+                    }
+
+                    for (int i = 0; i < _end; i++)
+                    {
+                        if (_circularBuffer[i] != null && _circularBuffer[i].Equals(item))
+                        {
+                            return true;
+                        }
+                    }
+                }
+            }
+
+            return false;
         }
         /// <summary>
         /// Copies this buffer to an array
         /// </summary>
-        public void CopyTo(T[] array, int arrayIndex) 
+        public void CopyTo(T[] array, int arrayIndex)
         {
-            if (array == null) 
+            if (array == null)
             {
                 throw new ArgumentNullException("array can not be null");
             }
 
-            if (array.Length == 0 || arrayIndex >= array.Length || arrayIndex < 0) 
+            if (array.Length == 0 || arrayIndex >= array.Length || arrayIndex < 0)
             {
                 throw new IndexOutOfRangeException();
             }
@@ -189,14 +253,14 @@ namespace DataStructures.Lists
             var enumarator = GetEnumerator();
 
             // Copy elements if there is any in the buffer and if the index is within the valid range
-            while (arrayIndex < array.Length) 
+            while (arrayIndex < array.Length)
             {
-                if (enumarator.MoveNext()) 
+                if (enumarator.MoveNext())
                 {
                     array[arrayIndex] = enumarator.Current;
                     arrayIndex++;
                 }
-                else 
+                else
                 {
                     break;
                 }
@@ -205,26 +269,73 @@ namespace DataStructures.Lists
         /// <summary>
         /// Removes an item from the buffer
         /// </summary>
-        public bool Remove(T item) 
+        public bool Remove(T item)
         {
-            if (!IsEmpty && Contains(item)) 
+            if (!IsEmpty && Contains(item))
             {
-               var sourceArray = _circularBuffer.Except(new T[] { item }).ToArray();
-                _circularBuffer = new T[Length + 1];
-                Array.Copy(sourceArray, _circularBuffer, sourceArray.Length);
-
-                if (!Equals(item,default(T))) 
+                int shiftSpace = 0;
+                if (_start < _end)
                 {
-                    _end = sourceArray.Length - 1;
-                    _count = sourceArray.Length-1;
+                    for (int i = _start; i < _end; i++)
+                    {
+                        if ((item == null && _circularBuffer[i] ==null) || (_circularBuffer[i] != null && _circularBuffer[i].Equals(item)))
+                        {
+                            shiftSpace++;
+                        }
+                        else
+                        {
+                            if (shiftSpace > 0)
+                            {
+                                _circularBuffer[i - shiftSpace] = _circularBuffer[i];
+                            }
+                        }
+                    }
+                    _end -= shiftSpace;
+                    _count -= shiftSpace;
                 }
-                else 
+                else
                 {
-                    _end = sourceArray.Length;
-                    _count = sourceArray.Length;
-                }
+                    for (int i = _start; i < _circularBuffer.Length; i++)
+                    {
+                        if ((item == null && _circularBuffer[i] == null) || (_circularBuffer[i] != null && _circularBuffer[i].Equals(item)))
+                        {
+                            shiftSpace++;
+                        }
+                        else
+                        {
+                            if (shiftSpace > 0)
+                            {
+                                _circularBuffer[i - shiftSpace] = _circularBuffer[i];
+                            }
+                        }
+                    }
 
-                return true;
+                    for (int i = 0; i < _end; i++)
+                    {
+                        if ((item == null && _circularBuffer[i] == null) || (_circularBuffer[i] != null && _circularBuffer[i].Equals(item)))
+                        {
+                            shiftSpace++;
+                        }
+                        else
+                        {
+                            if (shiftSpace > i)
+                            {
+                                _circularBuffer[_circularBuffer.Length + (i - shiftSpace)] = _circularBuffer[i];
+                            }
+                            else
+                            {
+                                _circularBuffer[i - shiftSpace] = _circularBuffer[i];
+                            }
+                        }
+                    }
+
+                    _end -= shiftSpace;
+                    if (_end < 0)
+                    {
+                        _end = _circularBuffer.Length + _end;
+                    }
+                    _count -= shiftSpace;
+                }
             }
 
             return false;
@@ -232,9 +343,9 @@ namespace DataStructures.Lists
         #endregion
     }
 
-    public class CircularBufferFullException : Exception 
+    public class CircularBufferFullException : Exception
     {
-        public CircularBufferFullException(string message) : base(message) 
+        public CircularBufferFullException(string message) : base(message)
         {
         }
     }

--- a/UnitTest/DataStructuresTests/CircularBufferTest.cs
+++ b/UnitTest/DataStructuresTests/CircularBufferTest.cs
@@ -80,19 +80,12 @@ namespace UnitTest.DataStructuresTests
             var result2 = circularBuffer.Pop();
             var result3 = circularBuffer.Pop();
             var result4 = circularBuffer.Pop();
-            var result5 = circularBuffer.Pop();
-            var result6 = circularBuffer.Pop();
-            var result7 = circularBuffer.Pop();
-            var result8 = circularBuffer.Pop();
 
             Assert.Equal(13, result1);
             Assert.Equal(43, result2);
             Assert.Equal(23, result3);
             Assert.Equal(2, result4);
-            Assert.Equal(0, result5);
-            Assert.Equal(0, result6);
-            Assert.Equal(0, result7);
-            Assert.Equal(0, result8);
+            Assert.Throws<InvalidOperationException>(()=> circularBuffer.Pop());
         }
 
         [Fact]
@@ -147,7 +140,7 @@ namespace UnitTest.DataStructuresTests
             circularBuffer.Add(34);
             circularBuffer.Add(24);
             //Testing contains
-            Assert.True(circularBuffer.Contains(3));
+            Assert.Contains<byte>(3, circularBuffer);
             
             //Testing CopyTo
             var array = new byte[3];
@@ -160,9 +153,7 @@ namespace UnitTest.DataStructuresTests
             Assert.Equal(3, circularBuffer.Count);
             //Testing clear
             circularBuffer.Clear();
-            Assert.Equal(0, circularBuffer.Pop());
-            Assert.Equal(0, circularBuffer.Pop());
-            Assert.Equal(0, circularBuffer.Pop());
+            Assert.Throws<InvalidOperationException>(() => circularBuffer.Pop());
             Assert.Empty(circularBuffer);
         }
         [Fact]
@@ -254,6 +245,86 @@ namespace UnitTest.DataStructuresTests
             Assert.Equal("three", stringBuffer.Pop());
             Assert.Equal("four", stringBuffer.Pop());
             Assert.Equal("five", stringBuffer.Pop());
+
+
+            //Test for removing overrided buffer
+            circularBuffer = new CircularBuffer<byte>(12);
+            circularBuffer.Add(1);
+            circularBuffer.Add(0);
+            circularBuffer.Add(2);
+            circularBuffer.Add(0);
+            circularBuffer.Add(3);
+            circularBuffer.Add(0);
+            circularBuffer.Add(4);
+            circularBuffer.Add(0);
+            circularBuffer.Add(5);
+            circularBuffer.Add(0);
+            circularBuffer.Add(6);
+            circularBuffer.Add(0);
+            circularBuffer.Add(7);
+            circularBuffer.Add(0);
+            circularBuffer.Add(8);
+
+
+            circularBuffer.Remove(0);
+            Assert.Equal(6, circularBuffer.Count);
+
+            Assert.Equal(3, circularBuffer.Pop());
+            Assert.Equal(4, circularBuffer.Pop());
+            Assert.Equal(5, circularBuffer.Pop());
+            Assert.Equal(6, circularBuffer.Pop());
+            Assert.Equal(7, circularBuffer.Pop());
+            Assert.Equal(8, circularBuffer.Pop());
+        }
+
+        [Fact]
+        public static void TestImplimentEnumerator()
+        {
+            Random rnd = new Random();
+            int[] values = new int[20];
+            for (int i = 0; i < values.Length; i++)
+                values[i] = rnd.Next(1, 99);
+            string arrayValue = string.Join(", ", values);
+
+            // buffer write two circles 
+            CircularBuffer<int> buffer = new CircularBuffer<int>(values.Length / 2);
+            var subvalues = new int[buffer.Length];
+
+            Array.Copy(values, values.Length - buffer.Length, subvalues, 0, buffer.Length);
+
+            foreach (int value in values)
+                buffer.Add(value);
+
+            string arraySubValue = string.Join(", ", subvalues);
+            string bufferValue = string.Join(", ", buffer);
+
+            Assert.Equal(arraySubValue, bufferValue);
+
+
+            // buffer not write full circle
+            buffer = new CircularBuffer<int>(values.Length + 2);
+            foreach (int value in values)
+                buffer.Add(value);
+
+            bufferValue = string.Join(", ", buffer);
+
+            Assert.Equal(arrayValue, bufferValue);
+
+
+            // buffer write over one circle
+            buffer = new CircularBuffer<int>(values.Length/2 + 2);
+            foreach (int value in values)
+                buffer.Add(value);
+
+            buffer.Pop();
+            buffer.Pop();
+
+            subvalues = new int[10];
+            Array.Copy(values, values.Length - 10, subvalues, 0, 10);
+            arraySubValue = string.Join(", ", subvalues);
+            bufferValue = string.Join(", ", buffer);
+
+            Assert.Equal(arraySubValue, bufferValue);
         }
     }
 }


### PR DESCRIPTION
### Description

fixed issue #155 
improve data struct:
- Pop now work like a stack (throw InvalidOperationException when pop an empty  CircularBuffer)
- No extra item in the inner array
- Clear array instead of create anew 
- Fixed bad implement of IEnumerable (incorrect GetEnumerator, Contains, Remove)

### Checklist

- [x] An issue was first created **before** opening this pull request
- [x] The new code follows the [contribution guidelines](CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests to ensure that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

