### PR TITLE
Modernized null checks by using `nameof()` operator

### DIFF
--- a/Algorithms/Strings/EditDistance.cs
+++ b/Algorithms/Strings/EditDistance.cs
@@ -14,8 +14,15 @@ namespace Algorithms.Strings
         public static Int64 GetMinDistance(string source, string destination, EditDistanceCostsMap<Int64> distances)
         {
             // Validate parameters and TCost.
-            if (source == null || destination == null || distances == null)
-                throw new ArgumentNullException("Some of the parameters are null.");
+            if (source == null)
+                throw new ArgumentNullException(nameof(source));
+
+            if (destination == null)
+                throw new ArgumentNullException(nameof(destination));
+
+            if (distances == null)
+                throw new ArgumentNullException(nameof(distances));
+
             if (source == destination)
                 return 0;
 
@@ -59,8 +66,15 @@ namespace Algorithms.Strings
         public static Int32 GetMinDistance(string source, string destination, EditDistanceCostsMap<Int32> distances)
         {
             // Validate parameters and TCost.
-            if (source == null || destination == null || distances == null)
-                throw new ArgumentNullException("Some of the parameters are null.");
+            if (source == null)
+                throw new ArgumentNullException(nameof(source));
+
+            if (destination == null)
+                throw new ArgumentNullException(nameof(destination));
+
+            if (distances == null)
+                throw new ArgumentNullException(nameof(distances));
+
             var longDistance = new EditDistanceCostsMap<long>(
                 insertionCost: Convert.ToInt64(distances.InsertionCost),
                 deletionCost: Convert.ToInt64(distances.DeletionCost),
@@ -75,8 +89,15 @@ namespace Algorithms.Strings
         public static Int16 GetMinDistance(string source, string destination, EditDistanceCostsMap<Int16> distances)
         {
             // Validate parameters and TCost.
-            if (source == null || destination == null || distances == null)
-                throw new ArgumentNullException("Some of the parameters are null.");
+            if (source == null)
+                throw new ArgumentNullException(nameof(source));
+
+            if (destination == null)
+                throw new ArgumentNullException(nameof(destination));
+
+            if (distances == null)
+                throw new ArgumentNullException(nameof(distances));
+
             var longDistance = new EditDistanceCostsMap<long>(
                 insertionCost: Convert.ToInt64(distances.InsertionCost),
                 deletionCost: Convert.ToInt64(distances.DeletionCost),

--- a/Algorithms/Trees/BinaryTreeRecursiveWalker.cs
+++ b/Algorithms/Trees/BinaryTreeRecursiveWalker.cs
@@ -180,7 +180,7 @@ namespace Algorithms.Trees
         public static void PrintAll<T>(BSTNode<T> BinaryTreeRoot, TraversalMode Mode=TraversalMode.InOrder) where T : IComparable<T>
         {
             if (BinaryTreeRoot == null)
-                throw new ArgumentNullException("Tree root cannot be null.");
+                throw new ArgumentNullException(nameof(BinaryTreeRoot), "Tree root cannot be null.");
 
             var printAction = new Action<T>((T nodeValue) =>
                 System.Console.Write(String.Format("{0} ", nodeValue)));
@@ -196,10 +196,10 @@ namespace Algorithms.Trees
         public static void ForEach<T>(BSTNode<T> BinaryTreeRoot, Action<T> Action, TraversalMode Mode=TraversalMode.InOrder) where T : IComparable<T>
         {
             if (BinaryTreeRoot == null)
-                throw new ArgumentNullException("Tree root cannot be null.");
+                throw new ArgumentNullException(nameof(BinaryTreeRoot), "Tree root cannot be null.");
             
             if (Action == null)
-                throw new ArgumentNullException("Action<T> Action cannot be null.");
+                throw new ArgumentNullException(nameof(Action), "Action<T> Action cannot be null.");
 
             // Traverse
             switch (Mode)
@@ -226,7 +226,7 @@ namespace Algorithms.Trees
         public static bool Contains<T>(BSTNode<T> BinaryTreeRoot, T Value, TraversalMode Mode=TraversalMode.InOrder) where T : IComparable<T>
         {
             if (BinaryTreeRoot == null)
-                throw new ArgumentNullException("Tree root cannot be null.");
+                throw new ArgumentNullException(nameof(BinaryTreeRoot), "Tree root cannot be null.");
 
             // Traverse
             // Traverse
@@ -250,7 +250,7 @@ namespace Algorithms.Trees
         public static bool BinarySearch<T>(BSTNode<T> BinaryTreeRoot, T Value, TraversalMode Mode=TraversalMode.InOrder) where T : IComparable<T>
         {
             if (BinaryTreeRoot == null)
-                throw new ArgumentNullException("Tree root cannot be null.");
+                throw new ArgumentNullException(nameof(BinaryTreeRoot), "Tree root cannot be null.");
 
             // Traverse
             // Traverse

--- a/DataStructures/Heaps/BinaryMaxHeap.cs
+++ b/DataStructures/Heaps/BinaryMaxHeap.cs
@@ -250,8 +250,11 @@ namespace DataStructures.Heaps
         /// </summary>
         public BinaryMaxHeap<T> Union(ref BinaryMaxHeap<T> firstMaxHeap, ref BinaryMaxHeap<T> secondMaxHeap)
         {
-            if (firstMaxHeap == null || secondMaxHeap == null)
-                throw new ArgumentNullException("Null heaps are not allowed.");
+            if (firstMaxHeap == null)
+                throw new ArgumentNullException(nameof(firstMaxHeap), "Null heaps are not allowed.");
+
+            if (secondMaxHeap == null)
+                throw new ArgumentNullException(nameof(secondMaxHeap), "Null heaps are not allowed.");
 
             // Create a new heap with reserved size.
             int size = firstMaxHeap.Count + secondMaxHeap.Count;

--- a/DataStructures/Heaps/BinaryMinHeap.cs
+++ b/DataStructures/Heaps/BinaryMinHeap.cs
@@ -259,8 +259,11 @@ namespace DataStructures.Heaps
         /// </summary>
         public BinaryMinHeap<T> Union(ref BinaryMinHeap<T> firstMinHeap, ref BinaryMinHeap<T> secondMinHeap)
         {
-            if (firstMinHeap == null || secondMinHeap == null)
-                throw new ArgumentNullException("Null heaps are not allowed.");
+            if (firstMinHeap == null)
+                throw new ArgumentNullException(nameof(firstMinHeap), "Null heaps are not allowed.");
+
+            if (secondMinHeap == null)
+                throw new ArgumentNullException(nameof(secondMinHeap), "Null heaps are not allowed.");
 
             // Create a new heap with reserved size.
             int size = firstMinHeap.Count + secondMinHeap.Count;

--- a/DataStructures/Heaps/BinomialMinHeap.cs
+++ b/DataStructures/Heaps/BinomialMinHeap.cs
@@ -137,8 +137,11 @@ namespace DataStructures.Heaps
         /// </summary>
         private BinomialNode<T> _combineTrees(BinomialNode<T> firstTreeRoot, BinomialNode<T> secondTreeRoot)
         {
-            if (firstTreeRoot == null || secondTreeRoot == null)
-                throw new ArgumentNullException("Either one of the nodes or both are null.");
+            if (firstTreeRoot == null)
+                throw new ArgumentNullException(nameof(firstTreeRoot), "First node is null.");
+
+            if (secondTreeRoot == null)
+                throw new ArgumentNullException(nameof(secondTreeRoot), "Second node is null.");
 
             if (secondTreeRoot.Value.IsLessThan(firstTreeRoot.Value))
                 return _combineTrees(secondTreeRoot, firstTreeRoot);

--- a/DataStructures/Lists/CircularBuffer.cs
+++ b/DataStructures/Lists/CircularBuffer.cs
@@ -177,7 +177,7 @@ namespace DataStructures.Lists
         {
             if (array == null) 
             {
-                throw new ArgumentNullException("array can not be null");
+                throw new ArgumentNullException(nameof(array), "array can not be null");
             }
 
             if (array.Length == 0 || arrayIndex >= array.Length || arrayIndex < 0) 

--- a/DataStructures/SortedCollections/SortedList.cs
+++ b/DataStructures/SortedCollections/SortedList.cs
@@ -180,7 +180,7 @@ namespace DataStructures.SortedCollections
         {
             // Validate the array argument
             if(array == null)
-                throw new ArgumentNullException("Array cannot be Null.");
+                throw new ArgumentNullException(nameof(array), "Array cannot be Null.");
             
             var enumerator = this._collection.GetInOrderEnumerator();
 


### PR DESCRIPTION
Also, decomposed some composite null checks into several, so that the exception would be more specific

### Checklist

- [ ] An issue was first created **before** opening this pull request
- [x] The new code follows the [contribution guidelines](CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas (Does not apply, it's self-documenting)
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests to ensure that prove my fix is effective or that my feature works (N/A)
- [x] New and existing unit tests pass locally with my changes

