### PR TITLE
Issue #11 & #153 fix - IsAnagram

### DIFF
--- a/Algorithms/Strings/Permutations.cs
+++ b/Algorithms/Strings/Permutations.cs
@@ -72,21 +72,16 @@ namespace Algorithms.Strings
             if (source.Equals(other, StringComparison.Ordinal))
                 return true;
 
-            int len = source.Length;
-            // Hash set which will contains all the characters present in input source.
-            var hashSetSourceChars = new HashSet<char>();
-            var hashSetOtherChars = new HashSet<char>();
-            for (int i = 0; i < len; i++)
+            var sourceChars = source.ToList();
+
+            foreach (char c in other)
             {
-                hashSetSourceChars.Add(source[i]);
-                hashSetOtherChars.Add(other[i]);
+                if (!sourceChars.Remove(c))
+                {
+                    return false;
+                }
             }
-            for (int i = 0; i < len; i++)
-            {
-                // Inputs are not Anargram if characers from *other are not present in *source.
-                if (!hashSetSourceChars.Contains(other[i])) return false;
-                if (!hashSetOtherChars.Contains(source[i])) return false;
-            }
+
             return true;
         }
     }

--- a/UnitTest/AlgorithmsTests/StringPermutationTests.cs
+++ b/UnitTest/AlgorithmsTests/StringPermutationTests.cs
@@ -37,6 +37,10 @@ namespace UnitTest.AlgorithmsTests
             one = "I am legion";    // L is small
             two = "legion I am";    // L is small
             Assert.True(Permutations.IsAnargram(one, two) == true);
+
+            one = "aab";
+            two = "abb";
+            Assert.False(Permutations.IsAnargram(one, two));
         }
     }
 }


### PR DESCRIPTION
### Description

Closes: #11 & #153
This PR fixes the IsAnagram method, making it so strings with the same characters, but different amount of them, will no longer be treated as anagrams.

The solution creates a list from the _source_ string while the _other_ string is enumerated to remove each char from the list. If a char could not be removed from the list, false is immediately returned.

The first commit adds a failing test: "aab" and "abb" (#153) which should result in false but doesn't.
The second commit fixes the method and the resulting test is now false and passes. 

### Checklist

- [x] An issue was first created **before** opening this pull request
- [x] The new code follows the [contribution guidelines](CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
_i believe comments are not necessary in this case_
- [ ] I have made corresponding changes to the documentation
_i didn't since the nature of this pr_
- [x] My changes generate no new warnings
- [x] I have added tests to ensure that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes